### PR TITLE
Document my ZST pointers asynchronous API design concept for libtock-rs.

### DIFF
--- a/zst_pointer_async/README.md
+++ b/zst_pointer_async/README.md
@@ -1,0 +1,357 @@
+# Asynchronous Components using Zero Sized Type Pointers
+
+Original author: Johnathan Van Why
+
+This document introduces a design (the "ZST-pointer" design) for asynchronous
+APIs in `libtock-rs`. It then gives an analysis of the design's tradeoffs, and
+the results of an experiment evaluating how this API design can live alongside
+a futures-based asynchronous API.
+
+## Background
+
+`libtock-rs` should expose asynchronous interfaces to the Tock kernel’s
+asynchronous APIs. There are a variety of mechanisms a library can use to expose
+an asynchronous API, with varying tradeoffs. The Rust community has settled on
+using Rust’s [Future](https://doc.rust-lang.org/core/future/trait.Future.html)
+trait to construct asynchronous APIs. Unfortunately, the analysis at [Futures
+versus no-Futures Size Comparison](../size_comparison) shows that the Future
+trait has size costs that are too high for many use cases of `libtock-rs`. As a
+result, we need an alternative design for `libtock-rs`’s asynchronous APIs.
+
+This document presents the "ZST-pointer" design, a candidate for the design of
+those asynchronous system call APIs.
+
+## Objectives of this design
+
+We have set the following objectives for the design of the system call APIs:
+
+1. **Asynchronous:** They must support asynchronous operation, as Tock OS has an
+   asynchronous design and many userspace binaries will need to perform
+   concurrent operations.
+1. **Lightweight:** To maximize the amount of functionality that can be
+   incorporated into a single Tock board, Tock applications must occupy minimal
+   flash and RAM space. Ideally, the abstractions required to support
+   asynchronous operation would have no impact on binary size, RAM usage, or
+   execution time.
+1. **Incremental migration from futures:** If we develop an
+   expensive-but-convenient futures API and an efficient-but-inconvenient API
+   independently, then it becomes difficult for application developers to choose
+   what API to build their applications against. Choosing the
+   efficient-but-inconvenient API for non-constrained applications wastes
+   engineering effort. Choosing the expensive-but-convenient API for a new
+   application runs the risk of requiring an application rewrite down the road
+   when the application grows large. To make this decision more reasonable, and
+   to prevent large application rewrite projects, we want to make it possible to
+   incrementally migrate a large application from the futures-based API to the
+   new API.
+
+There were a few other considerations as well:
+
+*  I tried to design the asynchronous APIs using only stable Rust features.
+*  Testability: we want to thoroughly unit-test (and occasionally
+   integration-test) all system call interfaces. This mostly means making the
+   API design dependency injection friendly.
+*  Understandability/maintainability.
+
+## ZST Pointer Design
+
+The design is based on the Tock kernel's asynchronous constructs, and keeps two
+of its major concepts:
+
+1. **A static graph of interacting state machines:** The Tock kernel has a
+   statically-specified graph of objects that interact with each other. It is
+   uncommon to use dynamic handles (which is the norm when using futures), which
+   minimizes overhead. It is normal for objects' interfaces to represent state
+   machines, and for their clients to rely on that state machine's behavior to
+   minimize the amount of duplicate state kept in RAM.
+1. **Split-phase calls:** If object `A` wants to invoke an asynchronous
+   operation implemented by object `B`, `A` calls a method on `B` to start the
+   operation, which returns without blocking, then `B` calls `A` back when the
+   operation is finished.
+
+For example, in the Tock kernel, a connection between an object `Bar` and an
+interface it depends on `Foo` would look like:
+
+```
+// The API Bar depends on.
+trait Foo {
+    fn foo(&self);
+}
+
+// Implemented by Bar; contains a callback called when the Foo::foo operation is
+// complete.
+trait FooClient {
+    fn foo_done(&self);
+}
+
+// Implemented by objects using Bar, contains a callback called when Bar's
+// operation completes.
+trait BarClient {
+    fn bar_done(&self);
+}
+
+// The `Bar` object. Note that the Foo's type is injected statically, but a
+// reference to the Foo is injected dynamically. Bar's client is injected fully
+// dynamically.
+struct Bar<F: Foo> {
+    foo: &F,  // 1 word
+    client: &dyn BarClient,  // 2 words
+}
+
+impl<F: Foo> FooClient for Bar<F> { ... }
+```
+
+The Tock kernel's implementation has unnecessary overhead. Objects in the Tock
+kernel contain references to their dependencies (objects that implement APIs
+that they need), even though those dependencies have locations known at compile
+time. For example, `LowLevelDebug` carries a `&uart::Transmit`, which costs 1
+word in RAM. Worse, the callback portion of the split-phase calls is generally
+implemented with `&dyn` references, which has the following costs:
+
+1. 2 words of space in RAM (data pointer + vtable pointer)
+1. A vtable in flash with 3 words Tock doesn't use (size, alignment, and
+   destructor).
+1. Prevents those calls from being inlined. LLVM has devirtualization to
+   alleviate this but it is not very effective in practice (in part because it
+   operates on bitcode types rather than Rust types).
+
+In the proposed design, `Bar` does not store a reference to a `Foo`, it stores a
+type that can forward calls to the `Foo`. That type is injected as a dependency
+of `Bar` via static polymorphism. Similarly, the `BarClient` is injected via
+dependency injection:
+
+```
+// FooPtr is implemented by a type that knows how to find an implementation of
+// `Foo`.
+trait FooPtr: Copy {
+    // If FooPtr is zero-sized, then the `self` argument has no cost.
+    fn foo(self);
+}
+
+// FooClient is unchanged from the previous example.
+trait FooClient {
+    fn foo_done(&self);
+}
+
+// BarClientPtr is implemented by a type that knows how to find an
+// implementation of `BarClient`. Like FooPtr, BarClientPtr may be implemented
+// as a zero-sized type.
+trait BarClientPtr: Copy {
+    fn bar_done(self);
+}
+
+trait BarDependencies : FooPtr + BarClientPtr {}
+
+struct Bar<D: BarDependencies> {
+    deps: BarDependencies,  // May be zero-sized.
+}
+
+impl<D: BarDependencies> FooClient for Bar<D> { ... }
+```
+
+`FooPtr` and `BarClientPtr` would be implemented by the code that instantiates
+the `Foo` and the `BarClient`, respectively. If the `Foo` and `BarClient` are
+`static` items, then `FooPtr` and `BarClientPtr` can be zero-sized types and
+carry no run-time overhead. The downside of this approach is the increased
+boilerplate relative to the kernel's approach (for the `FooPtr`, `BarClientPtr`,
+and `BarDependencies` implementations).
+
+Because the API replaces Rust's native reference types with new types that have
+similar functionality but are zero-sized types (ZSTs), I'm calling this the "ZST
+Pointer" approach to asynchronous APIs.
+
+In practice, there are a lot of variations on this approach that are possible,
+such as using generic traits to represent the *-Ptr types (discussed below). My
+implementation of this approach is in the [lw/](lw/) directory. My
+implementation of a futures-based API on top of the lightweight API is in the
+[futures/](futures/) directory. Neither module has been cleaned up for
+readability; they are contained as a research archive rather than as an example.
+
+## `Static` and `Sync`
+
+Buffers and callbacks given to the kernel must be of `static` lifetime. As a
+result, we need a way to store the userspace API objects in `static` variables.
+`static mut` is unsafe, and there is a
+[proposal](https://github.com/rust-lang/rust/issues/53639) to deprecate it from
+the language. Like the Tock kernel's coding style, the ZST pointer coding style
+makes heavy use of shared references, which are not `Sync`. In Rust, `static`
+items must be `Sync` (for thread safety), so we needed an additional abstraction
+to prevent the proliferation of `unsafe`.
+
+### Approach 1: `TockStatic<T>`
+
+`Sync` is only relevant in a multithreaded context, and `libtock-rs`'s runtime
+is (currently) single-threaded. With `libtock-rs`'s runtime, it is sound to
+implement `Sync` for any type. To implement this, we can introduce a wrapper
+type `TockStatic<T>` that allows us to make any type `Sync`:
+
+```
+pub struct TockStatic<T> {
+    value: T,
+}
+
+impl<T> TockStatic<T> {
+    pub const fn new(value: T) -> TockStatic<T> {
+        TockStatic { value }
+    }
+}
+
+unsafe impl<T> Sync for TockStatic<T> {}
+
+impl<T> core::ops::Deref for TockStatic<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+```
+
+It is important that the above type only be exposed to crates that link in
+`libtock-core`'s runtime, as it is wildly unsafe in multithreaded environments!
+
+`TockStatic<T>` carries the downside that its API *cannot* be implemented
+soundly in multithreaded environments, which would become a problem if we decide
+to add a multithreaded runtime to `libtock-rs`.
+
+### Approach 2: `SyncCell<T>`
+
+After implementing `TockStatic<T>` and using it for a while, I started seeing
+the following pattern appear repeatedly: `TockStatic<Cell<T>>`. I realized that
+most of `core::cell::Cell`'s API could be implemented in a threadsafe manner by
+disabling thread switching, with no impact on the size of the object. Disabling
+thread switching for all operations on the cell would prevent any thread
+accessing that cell from being preempted by another application thread,
+preventing concurrent accesses to the same data.
+
+Based on this observation, I introduced `SyncCell<T>`, which is essentially
+`Cell<T>` but implements `Sync`. `SyncCell` is implemented in
+[sync_cell.rs](lw/sync_cell.rs). `SyncCell` omits some casting-style methods
+that are not compatible with a mutex-based implementation.
+
+### Approach 3: Mutexes
+
+Alternatively, `libtock-rs`'s runtime(s) could expose mutex types that userspace
+code uses to safely store types in `static` items. Because a mutex's API is less
+pleasant to use than the above options (and that verbose code would be pervasive
+in `libtock-rs` and application code), I opted not to expose a mutex-like API in
+my prototypes.
+
+## Incremental Migration Experiment
+
+The above implementation is -- by design -- asynchronous and lighter-weight than
+the kernel's code structure. However, it is not immediately obvious that a large
+application can be migrated from a futures-based API to the ZST pointer API. To
+test this, I implemented a futures-based API on top of the ZST pointer API,
+ported [OpenSK](https://www.github.com/google/OpenSK) to it, then incrementally
+migrated OpenSK to the ZST pointer API.
+
+### Learnings
+
+The futures implementation needs to use virtualized versions of the underlying
+drivers. If, for example, the futures API does not use a virtualized button
+driver, then all uses of the buttons API will need to be migrated from the
+futures-based API to the ZST pointer API simultaneously. When the buttons
+futures are used in futures combinators, that will cause a cascade where other
+API usages would need to be migrated at the same time. Building the futures API
+atop a virtualized ZST pointer API prevents this cascade.
+
+Once I migrated the futures to use virtualized versions of the underlying
+drivers, completing the incremental migration was straightforward.
+
+## Additional Ideas
+
+### Generic Traits
+
+Instead of making each object that exposes asynchronous methods add 4 traits
+(the object's API, a zero-sized pointer to the object, the client API, and a
+pointer to the client), we can instead use a fixed set of generic traits.
+
+The first trait is implemented by objects that support an asynchronous call:
+
+```
+pub trait AsyncFn<Args, SyncOutput> {
+    fn call(&self, args: Args) -> SyncOutput;
+}
+```
+
+The second is implemented by zero-sized references to the above objects:
+
+```
+pub trait AsyncFnPtr<Args, SyncOutput> : Copy {
+    fn call(self, args: Args) -> SyncOutput;
+}
+```
+
+The third is implemented by clients of objects that support an asynchronous
+call, and contains the second phase of the split-phase call pattern:
+
+```
+pub trait AsyncClient<AsyncOutput> {
+    fn callback(&self, output: AsyncOutput);
+}
+```
+
+The last is implemented by lightweight pointers to `AsyncClient`s:
+
+```
+pub trait AsyncClientPtr<AsyncOutput> : Copy {
+    fn callback(self, output: AsyncOutput);
+}
+```
+
+Introducing these traits would add cognitive overhead to `libtock-rs`:
+understanding `libtock-rs` code (or apps written on top of `libtock-rs`) would
+require understanding these traits and how they relate to each other. However,
+they are useful in several ways:
+
+1.  They would reduce the amount of boilerplate in `libtock-rs` significantly.
+1.  The client traits are needed in order to write a `&dyn`-like abstraction for
+    virtualization layers. I implemented this idea as `DynCall` in
+    [lw/async_util.rs](lw/async_util.rs).
+1.  They allow the use of generic impls to generate the zero-sized pointer
+    types.
+
+We should probably have some form of these traits in `libtock-rs`.
+
+### Yieldable/Callback Context Types
+
+Allowing objects to call into each other arbitrarily has some issues. The Tock
+kernel developers have already experienced unintentional reentrancy and
+unbounded recursion. If object `A` tries to start an async operation on object
+`B`, but that operation fails to start, what happens if `B` calls `A`'s callback
+immediately? In practice, `A` isn't usually expecting that call, and it can lead
+to bugs (including infinite recursion). On the other hand, if `B` calls back
+into `A` is `A` allowed to immediately start a new operation in `B`? That seems
+useful.
+
+In practice, the Tock kernel solves this by asking objects to never call their
+second-phase callbacks in a first-phase context. For cases where `B` needs to
+generate a callback but is not expecting a later interrupt/callback, there is a
+deferred call mechanism for `B` to ask for a callback.
+
+We can introduce a zero-sized `CallbackMarker` type that is passed to deferred
+and kernel callbacks. Then second-phase callbacks could require a
+`CallbackMarker` to prevent them from being accidentally called from a
+first-phase context. This would involve the following change to the above
+traits:
+
+```
+pub trait AsyncClient<AsyncOutput> {
+    fn callback(&self, callback_marker: CallbackMarker, output: AsyncOutput);
+}
+
+pub trait AsyncClientPtr<AsyncOutput> : Copy {
+    fn callback(self, callback_marker: CallbackMarker, output: AsyncOutput);
+}
+```
+
+`CallbackMarker` could be defined by the crate/module that supplies the system
+call and deferred call implementation, with no public constructor. Then it would
+not be possible for application-level code to incorrectly create a
+`CallbackMarker`.
+
+A similar problem exists for calling `yield()` (which should only be called from
+synchronous contexts). However, there isn't as elegant a solution, because user
+code needs to be able to call into `yield()` from main, which cannot accept
+arguments.

--- a/zst_pointer_async/README.md
+++ b/zst_pointer_async/README.md
@@ -59,11 +59,11 @@ The design is based on the Tock kernel's asynchronous constructs, and keeps two
 of its major concepts:
 
 1. **A static graph of interacting state machines:** The Tock kernel has a
-   statically-specified graph of objects that interact with each other. It is
-   uncommon to use dynamic handles (which is the norm when using futures), which
-   minimizes overhead. It is normal for objects' interfaces to represent state
-   machines, and for their clients to rely on that state machine's behavior to
-   minimize the amount of duplicate state kept in RAM.
+   statically-specified graph of objects (as in OOP) that interact with each
+   other. It is uncommon to use dynamic handles (which is the norm when using
+   futures), which minimizes overhead. It is normal for objects' interfaces to
+   represent state machines, and for their clients to rely on that state
+   machine's behavior to minimize the amount of duplicate state kept in RAM.
 1. **Split-phase calls:** If object `A` wants to invoke an asynchronous
    operation implemented by object `B`, `A` calls a method on `B` to start the
    operation, which returns without blocking, then `B` calls `A` back when the
@@ -113,7 +113,8 @@ implemented with `&dyn` references, which has the following costs:
    destructor).
 1. Prevents those calls from being inlined. LLVM has devirtualization to
    alleviate this but it is not very effective in practice (in part because it
-   operates on bitcode types rather than Rust types).
+   operates on bitcode types rather than Rust types). See also
+   https://github.com/rust-lang/rust/issues/45774
 
 In the proposed design, `Bar` does not store a reference to a `Foo`, it stores a
 type that can forward calls to the `Foo`. That type is injected as a dependency

--- a/zst_pointer_async/client_example.rs
+++ b/zst_pointer_async/client_example.rs
@@ -1,0 +1,97 @@
+//! Example client application for the ZST pointers API in the lw/ directory.
+//! This implements the same app used in the ../size_comparison writeup. The app
+//! blinks a light, except it turns the light off whenever a button is held.
+
+// -----------------------------------------------------------------------------
+// State machine graph definition.
+// It is possible to reduce the amount of boilerplate here with some
+// macro_rules! macros.
+// -----------------------------------------------------------------------------
+
+/// ButtonClientPtr directs button events from the button driver to the main App
+/// struct.
+#[derive(Clone, Copy)]
+struct ButtonClientPtr;
+impl lw::async_util::AsyncClientPtr<lw::button::Event> for ButtonClientPtr {
+    fn callback(self, output: lw::button::Event) {
+        APP.button_event(output);
+    }
+}
+/// BUTTON_DRIVER is the concrete instance of the button driver. Its client is
+/// APP.
+static BUTTON_DRIVER: lw::button::Driver<ButtonClientPtr> =
+    lw::button::Driver::new(ButtonClientPtr);
+
+/// ClockClientPtr directs timer events from the Clock to the main App struct.
+#[derive(Clone, Copy)]
+struct ClockClientPtr;
+impl lw::async_util::AsyncClientPtr<lw::time::AlarmFired> for ClockClientPtr {
+    fn callback(self, _output: lw::time::AlarmFired) {
+        APP.alarm_fired();
+    }
+}
+/// CLOCK is the concrete instance of lw::timer::Clock. Its client is APP.
+static CLOCK: lw::async_util::TockStatic<lw::time::Clock<ClockClientPtr>> =
+    lw::async_util::TockStatic::new(lw::time::Clock::new(ClockClientPtr));
+
+/// AppLed specifies the LED the app controls.
+struct AppLed;
+impl lw::led::LedIdx for AppLed {
+    const IDX: usize = 0;
+}
+/// LED is the concrete lw::led::Led instance. Its client is APP.
+static LED: lw::led::Led<AppLed> = lw::led::Led::new();
+
+/// APP is the struct containing the main application logic. It knows how to
+/// find its dependencies because it -- and its dependencies -- are all part of
+/// the application, rather than libtock-rs.
+static APP: App = App::new();
+
+// -----------------------------------------------------------------------------
+// End state machine graph definition.
+// -----------------------------------------------------------------------------
+
+const BUTTON_IDX: usize = 0;
+
+struct App {
+}
+
+impl App {
+    pub const fn new() -> App {
+        App {
+        }
+    }
+
+    pub fn init(&self) {
+        let _ = BUTTON_DRIVER.enable_interrupt(BUTTON_IDX);
+    }
+
+    pub fn run(&self) {
+        // Set the first alarm, then run the event loop.
+        while CLOCK.set_alarm(CLOCK.get_time() + 1000).is_err() {}
+        loop { libtock::syscalls::yieldk(); }
+    }
+
+    pub fn button_event(&self, event: lw::button::Event) {
+        if event.index == BUTTON_IDX && event.new_value {
+            // Button just pressed, turn off the LED.
+            LED.turn_off();
+        }
+    }
+
+    pub fn alarm_fired(&self) {
+        if BUTTON_DRIVER.get_state(BUTTON_IDX) == Ok(false) {
+            // Button is not pressed, toggle LED.
+            LED.toggle();
+        }
+        // Set the timer to fire again in 1000 ticks.
+        while CLOCK.set_alarm(CLOCK.get_time() + 1000).is_err() {}
+    }
+}
+
+pub fn main() {
+    APP.init();
+    CLOCK.init();
+
+    APP.run();
+}

--- a/zst_pointer_async/futures/alarm.rs
+++ b/zst_pointer_async/futures/alarm.rs
@@ -1,0 +1,53 @@
+/// Futures-based interface to wait for a given amount of time. Uses the
+/// lightweight timer/alarm driver.
+
+use core::task::{Context, Poll};
+use crate::lw::time::{AlarmClock, AlarmFired};
+
+pub struct AlarmClockClient;
+
+impl crate::lw::async_util::Client<AlarmFired> for AlarmClockClient {
+    fn callback(&self, _response: AlarmFired) {}
+}
+
+pub struct AlarmFuture<C: AlarmClock + 'static> {
+    clock: &'static C,
+    setpoint: u64,
+}
+
+impl<C: AlarmClock> AlarmFuture<C> {
+    // Sets an alarm for `delay` ticks in the future.
+    pub fn new(clock: &'static C, delay: u64) -> AlarmFuture<C> {
+        AlarmFuture { clock, setpoint: delay + clock.get_time() }
+    }
+}
+
+impl<C: AlarmClock> core::future::Future for AlarmFuture<C> {
+    type Output = ();
+
+    fn poll(self: core::pin::Pin<&mut Self>, _cx: &mut Context) -> Poll<()> {
+        let cur_alarm = self.clock.get_alarm();
+        if cur_alarm > self.setpoint {
+            if self.clock.set_alarm(self.setpoint).is_ok() {
+                return Poll::Pending;
+            }
+            // I'm not sure whether ignoring this error is a bug. This logic
+            // would probably change if we store a Waker.
+            let _ = self.clock.set_alarm(cur_alarm);
+            return Poll::Ready(());
+        }
+        Poll::Pending
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct FutureForwarder;
+
+impl crate::lw::async_util::Forwarder<AlarmFired> for FutureForwarder {
+    fn invoke_callback(self, _: AlarmFired) {
+        // No-op. The setpoint has already been reset, and the futures that
+        // expired will poll CLOCK to determine that they have expired.
+        // TODO: This should store a Waker and poll it instead of assuming
+        // futures will be polled.
+    }
+}

--- a/zst_pointer_async/futures/alarm.rs
+++ b/zst_pointer_async/futures/alarm.rs
@@ -41,10 +41,10 @@ impl<C: AlarmClock> core::future::Future for AlarmFuture<C> {
 }
 
 #[derive(Clone, Copy)]
-pub struct FutureForwarder;
+pub struct FutureClientPtr;
 
-impl crate::lw::async_util::Forwarder<AlarmFired> for FutureForwarder {
-    fn invoke_callback(self, _: AlarmFired) {
+impl crate::lw::async_util::AsyncClientPtr<AlarmFired> for FutureClientPtr {
+    fn callback(self, _: AlarmFired) {
         // No-op. The setpoint has already been reset, and the futures that
         // expired will poll CLOCK to determine that they have expired.
         // TODO: This should store a Waker and poll it instead of assuming

--- a/zst_pointer_async/futures/button.rs
+++ b/zst_pointer_async/futures/button.rs
@@ -1,0 +1,97 @@
+//! Futures-based interface to the "buttons" syscall API. The buttons API allows
+//! applications to read whether or not buttons are pressed and to receive
+//! notifications when a button's state changes.
+
+// TODO: This is definitely an interface that would appreciate `alloc`. We
+// currently make users statically allocate per-button data, but with `alloc`
+// that could be dynamic.
+
+use core::cell::Cell;
+use core::convert::TryFrom;
+use core::task::{Context, Poll};
+use crate::lw::async_util::{Forwarder, TockStatic};
+use crate::lw::button::{Driver, Event, GetStateError};
+use crate::returncode_subset;
+
+pub fn get_state(index: usize) -> Result<bool, GetStateError> {
+    DRIVER.get_state(index)
+}
+
+/// Holds static data structures required to route Button events to the correct
+/// future. Initializing ButtonFuture requires passing it a &'static Button.
+pub struct Button {
+    next: TockStatic<Cell<Option<&'static Button>>>,
+    state: TockStatic<Cell<ButtonState>>,
+}
+
+impl Button {
+    pub const fn new() -> Button {
+        Button { next: TockStatic::new(Cell::new(None)),
+                 state: TockStatic::new(Cell::new(ButtonState::Uninitialized)) }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum ButtonState {
+    Uninitialized,
+    Idle,
+    WaitingFor(Event),
+    Fired,
+}
+
+/// A future that waits for a button to be pressed or released.
+pub struct ButtonFuture {
+    button: &'static Button,
+}
+
+impl ButtonFuture {
+    /// Creates a new ButtonFuture that waits until the button state has the
+    /// specified value.
+    pub fn new(button: &'static Button, index: usize, new_value: bool) -> Result<ButtonFuture, StartError> {
+        if button.state.get() == ButtonState::Uninitialized {
+            button.next.set(BUTTON_LIST.replace(Some(button)));
+        } else if button.state.get() != ButtonState::Idle {
+            // This Button is currently in use.
+            return Err(StartError::EBUSY);
+        }
+        DRIVER.enable_interrupt(index).map_err(
+            |ie| TryFrom::try_from(ie as isize).unwrap_or(StartError::FAIL))?;
+        button.state.set(ButtonState::WaitingFor(Event { index, new_value }));
+        Ok(ButtonFuture { button })
+    }
+}
+
+returncode_subset![ pub enum StartError { FAIL, EBUSY, ENOMEM, EINVAL, ENODEVICE } ];
+
+impl core::future::Future for ButtonFuture {
+    type Output = ();
+
+    // TODO: This should store and invoke the Waker for compatibility with
+    // external future combinators. We don't currently do so.
+    fn poll(self: core::pin::Pin<&mut Self>, _cx: &mut Context) -> Poll<()> {
+        if let ButtonState::WaitingFor(_) = self.button.state.get() {
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }
+}
+
+static BUTTON_LIST: TockStatic<Cell<Option<&'static Button>>> = TockStatic::new(Cell::new(None));
+static DRIVER: Driver<FutureForwarder> = Driver::new(FutureForwarder);
+
+#[derive(Clone, Copy)]
+struct FutureForwarder;
+
+impl Forwarder<Event> for FutureForwarder {
+    fn invoke_callback(self, response: Event) {
+        let mut opt_button: Option<&'static Button> = BUTTON_LIST.get();
+        while let Some(button) = opt_button {
+            if let ButtonState::WaitingFor(event) = button.state.get() {
+                if event != response { break; }
+                button.state.set(ButtonState::Fired);
+            }
+            opt_button = button.next.get();
+        }
+    }
+}

--- a/zst_pointer_async/futures/combinator.rs
+++ b/zst_pointer_async/futures/combinator.rs
@@ -1,0 +1,31 @@
+/// Custom future combinators.
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+pub struct WaitFirst<L: Future, R: Future> {
+    left: L,
+    right: R,
+}
+
+impl<L: Future, R: Future> WaitFirst<L, R> {
+    pub fn new(left: L, right: R) -> WaitFirst<L, R> {
+        WaitFirst { left, right }
+    }
+}
+
+impl<L: Future, R: Future> Future for WaitFirst<L, R> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+        let self_mut = unsafe { self.get_unchecked_mut() };
+        if let Poll::Ready(_) = unsafe { Pin::new_unchecked(&mut self_mut.left ) }.poll(cx)  {
+            return Poll::Ready(());
+        }
+        if let Poll::Ready(_) = unsafe { Pin::new_unchecked(&mut self_mut.right) }.poll(cx)  {
+            return Poll::Ready(());
+        }
+        Poll::Pending
+    }
+}

--- a/zst_pointer_async/futures/executor.rs
+++ b/zst_pointer_async/futures/executor.rs
@@ -1,0 +1,23 @@
+//! Provides a Future executors for libtock-rs tasks.
+
+use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+/// Runs the provided Future until it completes, then returns the result.
+pub fn block_on<F: core::future::Future>(mut future: F) -> F::Output {
+    use core::ptr;
+
+    let waker = unsafe { Waker::from_raw(RawWaker::new(ptr::null(), &VTABLE)) };
+    let mut context = Context::from_waker(&waker);
+    loop {
+        let future = unsafe { core::pin::Pin::new_unchecked(&mut future) };
+        match future.poll(&mut context) {
+            Poll::Pending => crate::syscalls::yieldk(),
+            Poll::Ready(value) => return value,
+        }
+    }
+}
+
+static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+
+fn clone(data: *const ()) -> RawWaker { RawWaker::new(data, &VTABLE) }
+fn noop(_: *const ()) {}

--- a/zst_pointer_async/futures/mod.rs
+++ b/zst_pointer_async/futures/mod.rs
@@ -1,0 +1,7 @@
+/// Futures-based libtock-rs.
+
+pub mod alarm;
+pub mod button;
+pub mod combinator;
+pub mod executor;
+pub mod rng;

--- a/zst_pointer_async/futures/rng.rs
+++ b/zst_pointer_async/futures/rng.rs
@@ -1,0 +1,107 @@
+//! RNG driver. Fills user-provided buffers with random bytes.
+
+use core::cell::Cell;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use crate::lw::async_util::{Forwarder, TockStatic};
+use crate::lw::rng::{Buffer, FetchError, Rng};
+
+pub struct RngFuture {
+    _private: (),
+}
+
+impl core::future::Future for RngFuture {
+    type Output = Result<&'static mut [u8], LostBufferError>;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+        match STATE.take() {
+            State::Idle | State::LostBuffer => Poll::Ready(Err(LostBufferError)),
+            State::Busy => {
+                STATE.set(State::Busy);
+                Poll::Pending
+            },
+            State::Done(buffer) => {
+                Poll::Ready(Ok(buffer))
+            },
+        }
+    }
+}
+
+pub struct LostBufferError;
+
+impl core::fmt::Debug for LostBufferError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.write_str("LostBufferError")
+    }
+}
+
+impl RngFuture {
+    pub fn new(buffer: &'static mut [u8]) -> Result<RngFuture, StartError> {
+        let state = STATE.take();
+        if state != State::Idle {
+            STATE.set(state);
+            return Err(StartError::EBUSY);
+        }
+        match RNG.fetch(buffer) {
+            Ok(_) => { STATE.set(State::Busy); Ok(RngFuture { _private: () }) },
+            Err((FetchError::FAIL, _)) => Err(StartError::FAIL),
+            Err((FetchError::EBUSY, _)) => Err(StartError::EBUSY),  // Shouldn't happen...
+            Err((FetchError::ENODEVICE, _)) => Err(StartError::ENODEVICE),
+        }
+    }
+}
+
+pub enum StartError {
+    FAIL = -1,
+    EBUSY = -2,
+    ENODEVICE = -11,
+}
+
+impl core::fmt::Debug for StartError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.write_str("StartError::")?;
+        match self {
+            StartError::FAIL => f.write_str("FAIL"),
+            StartError::EBUSY => f.write_str("EBUSY"),
+            StartError::ENODEVICE => f.write_str("ENODEVICE"),
+        }
+    }
+}
+
+// Open question: Should the futures API depend on `alloc`? That would allow us
+// to recover from things like "someone started fetching random bytes then
+// core::mem::forgot the future".
+
+// TODO: To be compatible with the general futures ecosystem (e.g.
+// futures::stream::FuturesUnordered), we should trigger the Waker in
+// invoke_callback. We don't currently even store it.
+
+#[derive(PartialEq)]
+enum State {
+    Idle,
+    Busy,
+    LostBuffer,
+    Done(&'static mut [u8]),
+}
+
+impl core::default::Default for State {
+    fn default() -> State {
+        State::Idle
+    }
+}
+
+static RNG: TockStatic<Rng<RngForwarder>> = TockStatic::new(Rng::new(RngForwarder));
+static STATE: TockStatic<Cell<State>> = TockStatic::new(Cell::new(State::Idle));
+
+#[derive(Clone, Copy)]
+struct RngForwarder;
+
+impl Forwarder<Option<Buffer>> for RngForwarder {
+    fn invoke_callback(self, response: Option<Buffer>) {
+        if let Some(buffer) = response {
+            STATE.set(State::Done(buffer));
+        } else {
+            STATE.set(State::LostBuffer);
+        }
+    }
+}

--- a/zst_pointer_async/lw/async_util.rs
+++ b/zst_pointer_async/lw/async_util.rs
@@ -46,17 +46,17 @@ unsafe fn erased_call<T, C: Client<T>>(data: *const (), response: T) {
     C::callback(&*(data as *const C), response)
 }
 
-/// A trait for "forwarders", which are type system shims that route callbacks
-/// to the appropriate client. Asynchronous components are generally generic
-/// over a forwarder; the forwarder provides them a way to route a callback to
-/// the client that does not require the asynchronous component to store a
-/// pointer to the client.
+/// A trait for type system shims that route callbacks to the appropriate
+/// client. Asynchronous components are generally generic over an
+/// AsyncClientPtr; the AsyncClientPtr provides them a way to route a callback
+/// to the client that does not require the asynchronous component to store a
+/// real pointer to the client.
 ///
-/// The forwarders are Copy and take `self` (rather than `&self`) so that if
-/// they are implemented as a zero-sized type the self argument will have no
+/// The AsyncClientPtrs are Copy and take `self` (rather than `&self`) so that
+/// if they are implemented as a zero-sized type the self argument will have no
 /// overhead.
-pub trait Forwarder<T>: Copy {
-    fn invoke_callback(self, response: T);
+pub trait AsyncClientPtr<AsyncOutput>: Copy {
+    fn callback(self, output: AsyncOutput);
 }
 
 /// Container that wraps a global value and hands out `&'static mut` references

--- a/zst_pointer_async/lw/async_util.rs
+++ b/zst_pointer_async/lw/async_util.rs
@@ -1,0 +1,168 @@
+//! Module containing async building blocks used by this lightweight libtock-rs
+//! prototype.
+
+use core::cell::{Cell, UnsafeCell};
+
+/// A trait implemented by clients of asynchronous components. Has a callback
+/// that receives a value of type T.
+pub trait Client<T> {
+    fn callback(&self, response: T);
+}
+
+/// A lighter-weight version of &dyn Client<T>. &dyn references internally
+/// contain two pointers: the pointer to the object's data and a pointer to a
+/// vtable. The vtable contains the type's size, alignment, destructor, and
+/// callback pointer, and is therefore 4 words in size. DynClient contains two
+/// words: the data pointer and the callback pointer.
+pub struct DynClient<'a, T> {
+    data: *const (),
+
+    // Because we don't know the real type of client, we have to erase the type
+    // of the data pointer. As far as I can tell, Rust does not *guarantee* that
+    // two implementations of Client<T>::callback have the same ABI, even when
+    // the T is the same in both cases. Instead, we point to a shim that has a
+    // fixed ABI regardless of the underlying client, and hope that shim
+    // optimizes away.
+    callback: unsafe fn(*const (), T),
+
+    _phantom: core::marker::PhantomData<&'a dyn Client<T>>,
+}
+
+impl<'a, T> DynClient<'a, T> {
+    pub const fn new<C: Client<T>>(client: &'a C) -> DynClient<'a, T> {
+        DynClient {
+            data: client as *const C as *const (),
+            callback: erased_call::<T, C>,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    pub fn callback(&self, response: T) {
+        unsafe { (self.callback)(self.data, response); }
+    }
+}
+
+unsafe fn erased_call<T, C: Client<T>>(data: *const (), response: T) {
+    C::callback(&*(data as *const C), response)
+}
+
+/// A trait for "forwarders", which are type system shims that route callbacks
+/// to the appropriate client. Asynchronous components are generally generic
+/// over a forwarder; the forwarder provides them a way to route a callback to
+/// the client that does not require the asynchronous component to store a
+/// pointer to the client.
+///
+/// The forwarders are Copy and take `self` (rather than `&self`) so that if
+/// they are implemented as a zero-sized type the self argument will have no
+/// overhead.
+pub trait Forwarder<T>: Copy {
+    fn invoke_callback(self, response: T);
+}
+
+/// Container that wraps a global value and hands out `&'static mut` references
+/// to it. The reference validity is checked at runtime. StaticMutCell should be
+/// used in a normal `static` item, not a `static mut` item. It is only sound
+/// with `libtock-rs`'s threading model: it assumes there are no other running
+/// threads.
+pub struct StaticMutCell<T> {
+    value: UnsafeCell<T>,
+    borrowed: Cell<bool>,
+}
+
+// Assumes single-threaded operation. We implement Sync so a StaticMutCell can
+// be stored in a normal `static`, so that users see a safe interface.
+unsafe impl<T> Sync for StaticMutCell<T> {}
+
+impl<T> StaticMutCell<T> {
+    pub const fn new(value: T) -> StaticMutCell<T> {
+        StaticMutCell { value: UnsafeCell::new(value), borrowed: Cell::new(false) }
+    }
+
+    pub fn get(&'static self) -> Option<&'static mut T> {
+        if self.borrowed.get() {
+            return None;
+        }
+        self.borrowed.set(true);
+        Some(unsafe { &mut *self.value.get() })
+    }
+
+    pub fn unborrow(&self, reference: &'static mut T) {
+        // For safety, We need to make sure that `reference` points to *our* T,
+        // rather than a different T. StaticMutCell is never a ZST (because
+        // `borrowed` has positive size), so we cannot have two distinct
+        // StaticMutCells at the same address. Therefore we can just compare
+        // pointer values.
+        if self.value.get() == reference as *mut T {
+            self.borrowed.set(false);
+        }
+    }
+}
+
+/// TockStatic allows non-Sync objects to be used in `static` declarations. This
+/// is unsafe in general Rust, but safe in the context of Tock applications as
+/// Tock applications are always single-threaded.
+pub struct TockStatic<T> {
+    value: T,
+}
+
+impl<T> TockStatic<T> {
+    pub const fn new(value: T) -> TockStatic<T> {
+        TockStatic { value }
+    }
+}
+
+unsafe impl<T> Sync for TockStatic<T> {}
+
+impl<T> core::ops::Deref for TockStatic<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+// ClientList is essentially &[&dyn Client<T>], but zero-sized (to remove
+// runtime overhead).
+pub unsafe trait List<T> {
+    const LEN: usize;
+    fn get(&self) -> &'static [DynClient<'static, T>];
+}
+
+pub struct EmptyList<T> { _phantom: core::marker::PhantomData<T> }
+
+impl<T> EmptyList<T> {
+    pub const fn new() -> EmptyList<T> {
+        EmptyList { _phantom: core::marker::PhantomData }
+    }
+}
+
+unsafe impl<T> List<T> for EmptyList<T> {
+    const LEN: usize = 0;
+
+    fn get(&self) -> &'static [DynClient<'static, T>] {
+        &[]
+    }
+}
+
+#[repr(C)]
+pub struct ClientList<T: 'static, L: List<T>> {
+    dyn_client: DynClient<'static, T>,
+    rest: L,
+}
+
+impl<T: 'static, L: List<T>> ClientList<T, L> {
+    pub const fn new<C: Client<T>>(client: &'static C, rest: L) -> ClientList<T, L> {
+        ClientList { dyn_client: DynClient::new(client), rest }
+    }
+}
+
+unsafe impl<T: 'static, L: List<T>> List<T> for ClientList<T, L> {
+    const LEN: usize = L::LEN + 1;
+
+    fn get(&self) -> &'static [DynClient<'static, T>] {
+        use core::slice::from_raw_parts;
+        unsafe {
+            from_raw_parts(self as *const Self as *const DynClient<T>, L::LEN + 1)
+        }
+    }
+}

--- a/zst_pointer_async/lw/button.rs
+++ b/zst_pointer_async/lw/button.rs
@@ -1,0 +1,109 @@
+//! Interface to the "button" syscall API. The button API allows applications to
+//! read the state of the buttons and to receive interrupts when the button
+//! state changes.
+
+// TODO: Drivers that expose a mix of a synchronous and an asynchronous API are
+// somewhat painful to use purely synchronously, because they still demand a
+// forwarder even if one is not necessary. The "generic arguments only on the
+// impl" approach probably handles this better.
+
+use crate::lw::async_util::Forwarder;
+use crate::returncode_subset;
+use crate::syscalls::{command, subscribe_ptr};
+
+const DRIVER_NUM: usize = 3;
+const NUM_BUTTONS: usize = 0;
+const ENABLE_INTERRUPT: usize = 1;
+const DISABLE_INTERRUPT: usize = 2;
+const GET_STATE: usize = 3;
+const BUTTON_EVENT: usize = 0;
+
+#[derive(Clone, Copy, PartialEq)]
+pub struct Event {
+    pub index: usize,
+    pub new_value: bool,
+}
+
+pub struct Driver<F: Forwarder<Event>> {
+    forwarder: F,
+}
+
+impl<F: Forwarder<Event>> Driver<F> {
+    pub const fn new(forwarder: F) -> Driver<F> {
+        Driver { forwarder }
+    }
+
+    // TODO: Result<usize, CountError> takes 2 words but there's less than 1
+    // word worth of information there. If this is a repeated pattern (which
+    // seems likely), then we may want to create an abstraction that packs this
+    // information into a single isize (perhaps even with some "impossible
+    // value" information in there?).
+    pub fn get_num_buttons(&self) -> Result<usize, CountError> {
+        let result = unsafe { command(DRIVER_NUM, NUM_BUTTONS, 0, 0) };
+        // The only error we *should* get is ENODEVICE. If we get any other
+        // error, it seems reasonable to coerce that error into ENODEVICE to
+        // avoid including FAIL in CountError and increasing its size.
+        if result < 0 { return Err(CountError::ENODEVICE); }
+        Ok(result as usize)
+    }
+
+    pub fn enable_interrupt(&self, index: usize) -> Result<(), InterruptError> {
+        let mut result = unsafe {
+            subscribe_ptr(DRIVER_NUM, BUTTON_EVENT, callback::<F> as *const _,
+                          self as *const Self as usize)
+        };
+        if result == crate::result::SUCCESS {
+            result = unsafe { command(DRIVER_NUM, ENABLE_INTERRUPT, index, 0) };
+        }
+        match result {
+            crate::result::SUCCESS => Ok(()),
+            crate::result::ENOMEM => Err(InterruptError::ENOMEM),
+            crate::result::EINVAL => Err(InterruptError::EINVAL),
+            crate::result::ENODEVICE => Err(InterruptError::ENODEVICE),
+            _ => Err(InterruptError::FAIL),
+        }
+    }
+
+    pub fn disable_interrupt(&self, index: usize) -> Result<(), InterruptError> {
+        match unsafe { command(DRIVER_NUM, DISABLE_INTERRUPT, index, 0) } {
+            crate::result::SUCCESS => Ok(()),
+            crate::result::ENOMEM => Err(InterruptError::ENOMEM),
+            crate::result::EINVAL => Err(InterruptError::EINVAL),
+            crate::result::ENODEVICE => Err(InterruptError::ENODEVICE),
+            _ => Err(InterruptError::FAIL),
+        }
+    }
+
+    pub fn get_state(&self, index: usize) -> Result<bool, GetStateError> {
+        match unsafe { command(DRIVER_NUM, GET_STATE, index, 0) } {
+            0 => Ok(false),
+            1 => Ok(true),
+            // We coerce all unknown errors to ENODEVICE. ENODEVICE is the only
+            // error that should occur, and if another occurs then treating the
+            // system call driver as missing seems reasonable.
+            _ => Err(GetStateError::ENODEVICE),
+        }
+    }
+}
+
+returncode_subset![ pub enum CountError { ENODEVICE } ];
+returncode_subset![ pub enum InterruptError { FAIL, ENOMEM, EINVAL, ENODEVICE } ];
+returncode_subset![ pub enum GetStateError { ENODEVICE } ];
+
+// We don't use crate::syscalls::subscribe as that requires a unique reference
+// and we need subscribe to work with a shared reference. This is the callback
+// we use instead.
+unsafe extern fn callback<F: Forwarder<Event>>(index: usize, pressed: usize, _: usize, driver: usize) {
+    let driver = &*(driver as *const Driver<F>);
+    // Convert `pressed` into a bool for use in the Event. Security note:
+    // although `pressed` should always be 0 or 1, applications do not trust
+    // capsules (such as the Button driver), so we must not invoke UB if
+    // `pressed` takes another value. The lightest way to handle other events is
+    // to drop them, so that's what we de.
+    let new_value = match pressed {
+        0 => false,
+        1 => true,
+        _ => return,
+    };
+    driver.forwarder.invoke_callback(Event { index, new_value });
+}

--- a/zst_pointer_async/lw/console.rs
+++ b/zst_pointer_async/lw/console.rs
@@ -1,0 +1,76 @@
+/// Console driver. Only supports writing to the console.
+
+use core::ptr::null_mut;
+use crate::lw::async_util::Forwarder;
+use crate::returncode_subset;
+use crate::syscalls::{allow_ptr, command, subscribe_ptr};
+
+const DRIVER_NUM: usize = 1;
+const WRITE: usize = 1;
+const WRITE_COMPLETE: usize = 1;
+const WRITE_BUFFER: usize = 1;
+
+pub type Buffer = &'static mut [u8];
+
+// TODO: Should we have an abstraction for drivers that just hand a buffer to
+// the kernel and wait for a callback? This is the same logic as the RNG driver.
+
+// TODO: Evaluate the distinctions between ENODEVICE, ENOMEM, and FAIL.
+
+pub struct Console<F: Forwarder<Option<Buffer>>> {
+    buffer_data: core::cell::Cell<*mut u8>,
+    buffer_len: core::cell::Cell<usize>,
+
+    forwarder: F,
+}
+
+impl<F: Forwarder<Option<Buffer>>> Console<F> {
+    pub const fn new(forwarder: F) -> Console<F> {
+        Console {
+            buffer_data: core::cell::Cell::new(core::ptr::null_mut()),
+            buffer_len: core::cell::Cell::new(0),
+            forwarder
+        }
+    }
+
+    pub fn write(&'static self, buffer: Buffer) -> Result<(), (WriteError, Option<Buffer>)> {
+        if !self.buffer_data.get().is_null() { return Err((WriteError::EBUSY, Some(buffer))); }
+        match unsafe { subscribe_ptr(DRIVER_NUM, WRITE_COMPLETE, callback::<F> as *const _,
+                                     self as *const Self as usize) } {
+            0 => {},  // Success
+            crate::result::ENOMEM => return Err((WriteError::ENOMEM, Some(buffer))),
+            crate::result::ENODEVICE => return Err((WriteError::ENODEVICE, Some(buffer))),
+            _ => return Err((WriteError::FAIL, Some(buffer))),
+        }
+        if unsafe { allow_ptr(DRIVER_NUM, WRITE_BUFFER, buffer.as_mut_ptr(), buffer.len()) } != 0 {
+            return Err((WriteError::FAIL, Some(buffer)));
+        }
+        if unsafe { command(DRIVER_NUM, WRITE, buffer.len(), 0) } != 0 {
+            // Unable to start the fetch, but we've already allow()-ed the
+            // buffer to the kernel. Try to get it back.
+            return match unsafe { allow_ptr(DRIVER_NUM, WRITE_BUFFER, null_mut(), 0) } {
+                0 => Err((WriteError::FAIL, Some(buffer))),
+                _ => Err((WriteError::FAIL, None)),
+            }
+        }
+        self.buffer_data.set(buffer.as_mut_ptr());
+        self.buffer_len.set(buffer.len());
+        Ok(())
+    }
+}
+
+returncode_subset![ pub enum WriteError { FAIL, EBUSY, ENODEVICE, ENOMEM } ];
+
+unsafe extern fn callback<F: Forwarder<Option<Buffer>>>(_bytes_written: usize, _: usize, _: usize, console: usize) {
+    let console = &*(console as *const Console<F>);
+
+    if allow_ptr(DRIVER_NUM, WRITE_BUFFER, null_mut(), 0) != 0 {
+        // Failed to un-allow the buffer. We leave the buffer values set in
+        // Console, which puts it into a "poisoned" state where it will return
+        // BUSY forever.
+        console.forwarder.invoke_callback(None);
+    }
+    console.forwarder.invoke_callback(Some(
+        core::slice::from_raw_parts_mut(console.buffer_data.replace(null_mut()), console.buffer_len.get())
+    ));
+}

--- a/zst_pointer_async/lw/deferred.rs
+++ b/zst_pointer_async/lw/deferred.rs
@@ -1,0 +1,5 @@
+//! Allows components to request a "deferred" call, which is executed sometime
+//! after their operation ends. In practice, this effectively functions as a
+//! simulated kernel callback.
+
+

--- a/zst_pointer_async/lw/dyncall.rs
+++ b/zst_pointer_async/lw/dyncall.rs
@@ -1,0 +1,42 @@
+//! A lighter-weight alternative to Rust's virtual call abstractions.
+//! `DynCall<Args, Return>` functions similarly to a
+//! `&dyn Callable<Args, Return>`, but instead of being a (*data, *vtable) pair
+//! it is a (*data, *function) pair. This removes one level of indirection, and
+//! removes the entire vtable (which would be 4 words in size). The downside is
+//! it only supports a single method, and cannot be used with owning types (i.e.
+//! you cannot use it the same way as a &dyn reference in Box<&dyn Callable>).
+
+use core::num::NonZeroUsize;
+
+/// Represents a method on a type. This is intentionally similar to the Fn trait
+/// (which is unstable).
+pub trait Callable<Args, Return>: Sized {
+    fn call(&self, args: Args) -> Return;
+
+    /// Type-erased version of call, for use by DynCall. Safety: safe to call
+    /// iff `data` can safely be casted to &Self for the underlying type.
+    /// TODO: Verify this is deduplicated with call.
+    unsafe fn erased_call(data: NonZeroUsize, args: Args) -> Return {
+        Self::call(&*(data.get() as *const Self), args)
+    }
+}
+
+/// Lighter-weight version of `&dyn Callable<Args, Return>` that inlines the
+/// function pointer directly rather than indirecting through a vtable.
+pub struct DynCall<Args, Return> {
+    data: NonZeroUsize,
+    function: unsafe fn(NonZeroUsize, Args) -> Return,
+}
+
+impl<Args, Return> DynCall<Args, Return> {
+    /// Constructs a new dyncall pointing to the given callable object.
+    pub fn new<T: Callable<Args, Return>>(object: &T) -> Self {
+        DynCall { data: unsafe { NonZeroUsize::new_unchecked(object as *const T as usize) },
+                  function: T::erased_call }
+    }
+
+    /// Call the pointed-to method on the pointed-to object.
+    pub fn call(&self, args: Args) -> Return {
+        unsafe { (self.function)(self.data, args) }
+    }
+}

--- a/zst_pointer_async/lw/led.rs
+++ b/zst_pointer_async/lw/led.rs
@@ -1,0 +1,86 @@
+//! Driver for the LED capsule. Contains 2 interface levels: a write-only
+//! interface that lets users set and toggle LEDs and a read-write interface
+//! that tracks whether an LED is set.
+
+const DRIVER_NUM: usize = 2;
+const TURN_ON: usize = 1;
+const TURN_OFF: usize = 2;
+const TOGGLE: usize = 3;
+
+pub trait LedIdx {
+    const IDX: usize;
+}
+
+pub struct Led<I: LedIdx> {
+    _phantom: core::marker::PhantomData<I>,
+}
+
+impl<I: LedIdx> Led<I> {
+    pub const fn new() -> Led<I> {
+        Led { _phantom: core::marker::PhantomData }
+    }
+
+    fn led_op(&self, op: usize) -> Result<(), Error> {
+        use crate::syscalls::command;
+        match unsafe { command(DRIVER_NUM, op, I::IDX, 0) } {
+            0 => Ok(()),
+            -6 => Err(Error::EINVAL),
+            -11 => Err(Error::ENODEVICE),
+            _ => Err(Error::FAIL),
+        }
+    }
+
+    pub fn turn_on(&self) -> Result<(), Error> {
+        self.led_op(TURN_ON)
+    }
+
+    pub fn turn_off(&self) -> Result<(), Error> {
+        self.led_op(TURN_OFF)
+    }
+
+    pub fn toggle(&self) -> Result<(), Error> {
+        self.led_op(TOGGLE)
+    }
+}
+
+pub enum Error {
+    FAIL = -1,
+    EINVAL = -6,
+    ENODEVICE = -11,
+}
+
+/// LED driver that tracks the current state of the LED.
+pub struct TrackedLed<I: LedIdx> {
+    led: Led<I>,
+    state: core::cell::Cell<Option<bool>>,
+}
+
+impl<I: LedIdx> TrackedLed<I> {
+    pub fn new() -> TrackedLed<I> {
+        TrackedLed { led: Led::new(), state: Default::default() }
+    }
+
+    /// Returns the LED's state, if known. Returns None if we do not know
+    /// whether the LED is currently on.
+    pub fn get_state(&self) -> Option<bool> {
+        self.state.get()
+    }
+
+    /// Turns on the LED.
+    pub fn turn_on(&self) -> Result<(), Error> {
+        self.state.set(Some(true));
+        self.led.turn_on()
+    }
+
+    /// Turns off the LED.
+    pub fn turn_off(&self) -> Result<(), Error> {
+        self.state.set(Some(false));
+        self.led.turn_off()
+    }
+
+    /// Toggles the LED.
+    pub fn toggle(&self) -> Result<(), Error> {
+        self.state.set(self.state.get().map(core::ops::Not::not));
+        self.led.toggle()
+    }
+}

--- a/zst_pointer_async/lw/mod.rs
+++ b/zst_pointer_async/lw/mod.rs
@@ -1,0 +1,33 @@
+pub mod async_util;
+pub mod button;
+pub mod console;
+pub mod deferred;
+pub mod dyncall;
+pub mod led;
+pub mod returncode;
+pub mod rng;
+pub mod sync_cell;
+pub mod time;
+pub mod virt_time;
+
+// TODO: Figure out a way to initialize drivers that want or need runtime
+// initialization (e.g. calling subscribe() to set up static callbacks). We may
+// be able to use some sort of "init token" system (implemented kinda like
+// capabilities) to show that a driver is initialized -- but note that the
+// system cannot be trusted for safety unless we have a way to show the
+// particular instance was initialized. Even then, for subscriptions different
+// instances can overwrite each other, although that shouldn't result in safety
+// issues. That said, subscriptions may show up in the syscall traits, so
+// subscription initialization and clashes may not be a problem in the first
+// place.
+
+// TODO: Idea for an init system. Each init() method returns one token type.
+// Each method that requires initialization requires a second token type.
+// Constructing the second token type requires providing copies of the first
+// token type for each dependency of the component being initialized. I.e. if A
+// depends on B and C, then invoking A::do_thing() requires a token whose
+// construction requires the result of A::init(), B::init(), and C::init().
+// Doesn't solve the "exact same instance" problem, but I don't think that can
+// be solved. Still unclear whether it's better to have an init system that
+// doesn't guarantee the *correct* instances are initialized or to have no
+// forced init system.

--- a/zst_pointer_async/lw/returncode.rs
+++ b/zst_pointer_async/lw/returncode.rs
@@ -1,0 +1,136 @@
+//! Provides facilities for generating error enums representing a subset of the
+//! kernel's error codes (defined at
+//! https://github.com/tock/tock/blob/master/kernel/src/returncode.rs). To make
+//! conversions more efficient, they have the same numeric values as the
+//! ReturnCode values. They have fewer possibilites to prevent unnecessary match
+//! branches.
+
+/// Generates an enum with the specified subset of ReturnCode's values. For
+/// example:
+/// ```
+/// returncode_subset![ enum Error {
+///     SUCCESS,
+///     EOFF,
+/// } ];
+/// ```
+/// expands to:
+/// ```
+/// enum Error {
+///     SUCCESS = 0,
+///     EOFF = -4,
+/// };
+/// ```
+// TODO: Do we want to auto-implement TryFrom for the type? It's unclear whether
+// most uses of these structs would want to use custom code for each case or
+// whether there would be a significant number of drivers that would translate
+// directly. This may also change if we add a 1-word ReturnCode type that packs
+// a Result<positive isize, Error> into a single struct.
+// TODO: Do we want to have conversions between different ReturnCode subsets? If
+// so, how? Fallable at runtime? Enforced at compile-time (one trait per
+// ReturnCode variant?).
+// TODO: What is the backwards-compatibility story here? Can syscall APIs add
+// new errors codes as they wish? If not, then yay. If yes, do we want to do
+// something like #[non_exhaustive]? Do we want to force the userspace drivers
+// to coerce errors to the errors they've stabilized?
+#[macro_export]
+macro_rules! returncode_subset {
+    [$p:vis enum $name:ident $tree:tt] => {
+        $crate::returncode_with_vis![$p enum $name $tree];
+    };
+    [enum $name:ident $tree:tt] => {
+        $crate::returncode_with_vis![pub(self) enum $name $tree];
+    };
+}
+
+#[macro_export]
+macro_rules! returncode_with_vis {
+    [$p:vis enum $name:ident { $($v:ident),* }] => {
+        // TODO: Replace with a more efficient manual Debug implementation or
+        // some other trait (e.g. ufmt-like).
+        #[derive(Debug)]
+        $p enum $name { $($v = $crate::returncode_value![$v]),* }
+        $($crate::returncode_trait_impl!{$name, $v})*
+
+        // TODO: Evaluate whether we *want* TryFrom.
+        impl ::core::convert::TryFrom<isize> for $name {
+            type Error = ();  // TODO: Should probably be a custom error type.
+
+            fn try_from(value: isize) -> Result<Self, ()> {
+                match value {
+                    $($crate::returncode_value![$v] => Ok(Self::$v),)*
+                    _ => Err(()),
+                }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! returncode_value {
+    [SUCCESS] => (0);
+    [FAIL] => (-1);
+    [EBUSY] => (-2);
+    [EALREADY] => (-3);
+    [EOFF] => (-4);
+    [ERESERVE] => (-5);
+    [EINVAL] => (-6);
+    [ESIZE] => (-7);
+    [ECANCEL] => (-8);
+    [ENOMEM] => (-9);
+    [ENOSUPPORT] => (-10);
+    [ENODEVICE] => (-11);
+    [EUNINSTALLED] => (-12);
+    [ENOACK] => (-13);
+}
+
+#[macro_export]
+macro_rules! returncode_trait {
+    {SUCCESS}      => ($crate::lw::returncode::Success);
+    {FAIL}         => ($crate::lw::returncode::Fail);
+    {EBUSY}        => ($crate::lw::returncode::EBusy);
+    {EALREADY}     => ($crate::lw::returncode::EAlready);
+    {EOFF}         => ($crate::lw::returncode::EOff);
+    {ERESERVE}     => ($crate::lw::returncode::EReserve);
+    {EINVAL}       => ($crate::lw::returncode::EInval);
+    {ESIZE}        => ($crate::lw::returncode::ESize);
+    {ECANCEL}      => ($crate::lw::returncode::ECancel);
+    {ENOMEM}       => ($crate::lw::returncode::ENoMem);
+    {ENOSUPPORT}   => ($crate::lw::returncode::ENoSupport);
+    {ENODEVICE}    => ($crate::lw::returncode::ENoDevice);
+    {EUNINSTALLED} => ($crate::lw::returncode::EUninstalled);
+    {ENOACK}       => ($crate::lw::returncode::ENoAck);
+}
+
+// TODO: Figure out how to make these traits work (macro magic).
+#[macro_export]
+macro_rules! returncode_trait_impl {
+    {$n:ident, SUCCESS}      => (impl $crate::lw::returncode::Success      for $n { fn success()      -> Self { Self::SUCCESS      } });
+    {$n:ident, FAIL}         => (impl $crate::lw::returncode::Fail         for $n { fn fail()         -> Self { Self::FAIL         } });
+    {$n:ident, EBUSY}        => (impl $crate::lw::returncode::EBusy        for $n { fn ebusy()        -> Self { Self::EBUSY        } });
+    {$n:ident, EALREADY}     => (impl $crate::lw::returncode::EAlready     for $n { fn ealready()     -> Self { Self::EALREADY     } });
+    {$n:ident, EOFF}         => (impl $crate::lw::returncode::EOff         for $n { fn eoff()         -> Self { Self::EOFF         } });
+    {$n:ident, ERESERVE}     => (impl $crate::lw::returncode::EReserve     for $n { fn ereserve()     -> Self { Self::ERESERVE     } });
+    {$n:ident, EINVAL}       => (impl $crate::lw::returncode::EInval       for $n { fn einval()       -> Self { Self::EINVAL       } });
+    {$n:ident, ESIZE}        => (impl $crate::lw::returncode::ESize        for $n { fn esize()        -> Self { Self::ESIZE        } });
+    {$n:ident, ECANCEL}      => (impl $crate::lw::returncode::ECancel      for $n { fn encancel()     -> Self { Self::ECANCEL      } });
+    {$n:ident, ENOMEM}       => (impl $crate::lw::returncode::ENoMem       for $n { fn enomem()       -> Self { Self::ENOMEM       } });
+    {$n:ident, ENOSUPPORT}   => (impl $crate::lw::returncode::ENoSupport   for $n { fn enosupport()   -> Self { Self::ENOSUPPORT   } });
+    {$n:ident, ENODEVICE}    => (impl $crate::lw::returncode::ENoDevice    for $n { fn enodevice()    -> Self { Self::ENODEVICE    } });
+    {$n:ident, EUNINSTALLED} => (impl $crate::lw::returncode::EUninstalled for $n { fn euninstalled() -> Self { Self::EUNINSTALLED } });
+    {$n:ident, ENOACK}       => (impl $crate::lw::returncode::ENoAck       for $n { fn enoack()       -> Self { Self::ENOACK       } });
+}
+
+pub trait Success { fn success() -> Self; }
+pub trait Fail { fn fail() -> Self; }
+pub trait EBusy { fn ebusy() -> Self; }
+pub trait EAlready { fn ealready() -> Self; }
+pub trait EOff { fn eoff() -> Self; }
+pub trait EReserve { fn ereserve() -> Self; }
+pub trait EInval { fn einval() -> Self; }
+pub trait ESize { fn esize() -> Self; }
+pub trait ECancel { fn ecancel() -> Self; }
+pub trait ENoMem { fn enomem() -> Self; }
+pub trait ENoSupport { fn enosupport() -> Self; }
+pub trait ENoDevice { fn enodevice() -> Self; }
+pub trait EUninstalled { fn euninstalled() -> Self; }
+pub trait ENoAck { fn enoack() -> Self; }

--- a/zst_pointer_async/lw/rng.rs
+++ b/zst_pointer_async/lw/rng.rs
@@ -1,0 +1,86 @@
+//! Interface to the RNG capsule. Fills a provided buffer asynchronously with
+//! random bytes, then passes it back to the caller. Does not provide
+//! virtualization.
+//!
+//! RNG has a generic argument (ClientLink) which allows RNG to perform
+//! callbacks on its client.
+
+use core::cell::Cell;
+use core::ptr::null_mut;
+use crate::lw::async_util::Forwarder;
+use crate::syscalls::{allow_ptr, command, subscribe_ptr};
+
+const BUFFER_NUM: usize = 0;
+const DRIVER_NUM: usize = 0x40001;
+const GET_BYTES: usize = 1;
+const GET_BYTES_DONE: usize = 0;
+
+pub type Buffer = &'static mut [u8];
+
+/// The RNG driver itself.
+pub struct Rng<F: Forwarder<Option<Buffer>>> {
+    // The buffer corresponding to an ongoing fetch. buffer_data is null if
+    // there is no ongoing fetch. Stored as a raw pointer and length to avoid
+    // the undefined behavior that would result from holding a &[u8] pointing to
+    // data the kernel is mutating.
+    buffer_data: Cell<*mut u8>,
+    buffer_len: Cell<usize>,
+
+    forwarder: F,
+}
+
+impl<F: Forwarder<Option<Buffer>>> Rng<F> {
+    pub const fn new(forwarder: F) -> Rng<F> {
+        Rng { buffer_data: Cell::new(null_mut()), buffer_len: Cell::new(0), forwarder }
+    }
+
+    pub fn fetch(&'static self, buffer: Buffer) -> Result<(), (FetchError, Option<Buffer>)> {
+        if !self.buffer_data.get().is_null() { return Err((FetchError::EBUSY, Some(buffer))); }
+        match unsafe { subscribe_ptr(DRIVER_NUM, GET_BYTES_DONE, callback::<F> as *const _,
+                                     self as *const Self as usize) } {
+            0 => {},  // Success
+            -11 => return Err((FetchError::ENODEVICE, Some(buffer))),
+            _ => return Err((FetchError::FAIL, Some(buffer))),
+        }
+        if unsafe { allow_ptr(DRIVER_NUM, BUFFER_NUM, buffer.as_mut_ptr(), buffer.len()) } != 0 {
+            return Err((FetchError::FAIL, Some(buffer)));
+        }
+        if unsafe { command(DRIVER_NUM, GET_BYTES, buffer.len(), 0) } != 0 {
+            // Unable to start the fetch, but we've already allow()-ed the
+            // buffer to the kernel. Try to get it back.
+            return match unsafe { allow_ptr(DRIVER_NUM, BUFFER_NUM, null_mut(), 0) } {
+                0 => Err((FetchError::FAIL, Some(buffer))),
+                _ => Err((FetchError::FAIL, None)),
+            }
+        }
+        self.buffer_data.set(buffer.as_mut_ptr());
+        self.buffer_len.set(buffer.len());
+        return Ok(());
+    }
+}
+
+/// Error type for the RNG driver.
+// TODO: These are just the kernel-provided error types. For low-level drivers
+// that "have no failure modes of their own", should we just have a common error
+// type?
+pub enum FetchError {
+    FAIL = -1,        // Internal failure
+    EBUSY = -2,       // A fetch is ongoing.
+    ENODEVICE = -11,  // The kernel does not have the RNG capsule.
+}
+
+// We don't use crate::syscalls::subscribe as that requires a unique reference
+// and we need subscribe to work with a shared reference. This is the callback
+// we use instead.
+unsafe extern fn callback<F: Forwarder<Option<Buffer>>>(_: usize, _: usize, _: usize, rng: usize) {
+    let rng = &*(rng as *const Rng<F>);
+    if allow_ptr(DRIVER_NUM, BUFFER_NUM, null_mut(), 0) != 0 {
+        // Failed to un-allow the buffer. We leave the buffer values set in Rng,
+        // which puts it into a "poisoned" state where it will return BUSY
+        // forever.
+        rng.forwarder.invoke_callback(None);
+    }
+    rng.forwarder.invoke_callback(Some(
+        core::slice::from_raw_parts_mut(rng.buffer_data.replace(null_mut()), rng.buffer_len.get())
+    ));
+}

--- a/zst_pointer_async/lw/sync_cell.rs
+++ b/zst_pointer_async/lw/sync_cell.rs
@@ -1,0 +1,85 @@
+/// SyncCell exposes the a similar API to core::cell::Cell, but is Sync. In
+/// single-threaded environments (such as the current implementation of
+/// libtock-rs), a SyncCell has no overhead relative to a core::cell::Cell. In
+/// multi-threaded environments, SyncCell can be implemented using a mutex (or
+/// atomic types, if available).
+// repr(transparent) is ommitted because it is not compatible with a mutex-based
+// implementation.
+pub struct SyncCell<T: ?Sized> {
+    // This implementation is for single-threaded environments (i.e. the current
+    // libtock).
+    value: core::cell::Cell<T>,
+}
+
+unsafe impl<T: ?Sized> Sync for SyncCell<T> {}
+
+impl<T> SyncCell<T> {
+    pub const fn new(value: T) -> SyncCell<T> {
+        SyncCell { value: core::cell::Cell::new(value) }
+    }
+
+    pub fn set(&self, val: T) {
+        self.value.set(val);
+    }
+
+    pub fn swap(&self, other: &Self) {
+        self.value.swap(&other.value);
+    }
+
+    pub fn replace(&self, val: T) -> T {
+        self.value.replace(val)
+    }
+
+    pub fn into_inner(self) -> T {
+        self.value.into_inner()
+    }
+}
+
+impl<T: Copy> SyncCell<T> {
+    pub fn get(&self) -> T {
+        self.value.get()
+    }
+}
+
+impl<T: ?Sized> SyncCell<T> {
+    pub const fn as_ptr(&self) -> *mut T {
+        self.value.as_ptr()
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        self.value.get_mut()
+    }
+
+    // from_mut() is omitted because it is not compatible with a multithreaded
+    // runtime.
+}
+
+impl<T: Default> SyncCell<T> {
+    pub fn take(&self) -> T {
+        self.value.take()
+    }
+}
+
+// as_slice_of_cells() is omitted because it is not compatible with a
+// mutex-based implementation.
+
+impl<T: Copy> Clone for SyncCell<T> {
+    fn clone(&self) -> SyncCell<T> {
+        SyncCell { value: self.value.clone() }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.value.clone_from(&source.value);
+    }
+}
+
+// Debug skipped because it generates size bloat (TODO: introduce a
+// lighter-weight alternative and implement that instead).
+
+impl<T: Default> Default for SyncCell<T> {
+    fn default() -> SyncCell<T> {
+        SyncCell { value: Default::default() }
+    }
+}
+
+// TODO: The rest of the trait implementations

--- a/zst_pointer_async/lw/time.rs
+++ b/zst_pointer_async/lw/time.rs
@@ -13,10 +13,10 @@
 // wraparound, but the numbers returned by the kernel would match the second
 // sequence. Therefore, we need all queued alarm callbacks to run less than
 // 2^32 - UPDATE_PERIOD ticks after the alarm fires. We don't have a way to make
-// that happen (as Tock is not a RTOS) so we simply hope such a large delay
+// that happen (as Tock is not an RTOS) so we simply hope such a large delay
 // never happens.
 
-use crate::lw::async_util::Forwarder;
+use crate::lw::async_util::AsyncClientPtr;
 use crate::syscalls::{command, subscribe_ptr};
 
 const DRIVER_NUM: usize = 0;
@@ -25,7 +25,7 @@ const SET_ALARM: usize = 4;
 const ALARM_FIRED: usize = 0;
 const UPDATE_PERIOD: u32 = 1_000_000_000;
 
-pub struct Clock<F: Forwarder<AlarmFired>> {
+pub struct Clock<C: AsyncClientPtr<AlarmFired>> {
     // The time at which the client wants to be alerted.
     client_setpoint: core::cell::Cell<u64>,
 
@@ -33,7 +33,7 @@ pub struct Clock<F: Forwarder<AlarmFired>> {
     // kernel counter value at that time.
     last_callback: core::cell::Cell<u64>,
 
-    forwarder: F,
+    client_ptr: C,
 }
 
 pub trait AlarmClock {
@@ -42,12 +42,12 @@ pub trait AlarmClock {
     fn set_alarm(&self, time: u64) -> Result<(), InPast>;
 }
 
-impl<F: Forwarder<AlarmFired>> Clock<F> {
-    pub const fn new(forwarder: F) -> Clock<F> {
+impl<C: AsyncClientPtr<AlarmFired>> Clock<C> {
+    pub const fn new(client_ptr: C) -> Clock<C> {
         Clock {
             client_setpoint: core::cell::Cell::new(0),
             last_callback: core::cell::Cell::new(0),
-            forwarder
+            client_ptr
         }
     }
 
@@ -65,7 +65,7 @@ impl<F: Forwarder<AlarmFired>> Clock<F> {
     }
 }
 
-impl<F: Forwarder<AlarmFired>> AlarmClock for Clock<F> {
+impl<C: AsyncClientPtr<AlarmFired>> AlarmClock for Clock<C> {
     fn get_time(&self) -> u64 {
         calc_new_unwrapped(
             self.last_callback.get(),
@@ -106,16 +106,16 @@ fn calc_new_unwrapped(unwrapped: u64, ticks: u32) -> u64 {
 // We don't use crate::syscalls::subscribe as that requires a unique reference
 // and we need subscribe to work with a shared reference. This is the callback
 // we use instead.
-unsafe extern fn callback<F: Forwarder<AlarmFired>>(_: usize, expired: usize, _: usize, clock: usize) {
+unsafe extern fn callback<C: AsyncClientPtr<AlarmFired>>(_: usize, expired: usize, _: usize, clock: usize) {
     use core::cmp::min;
-    let clock = &*(clock as *const Clock<F>);
+    let clock = &*(clock as *const Clock<C>);
     clock.last_callback.set(calc_new_unwrapped(clock.last_callback.get(), expired as u32));
     loop {
         let tgt = min(clock.client_setpoint.get(), clock.last_callback.get() + UPDATE_PERIOD as u64);
         command(DRIVER_NUM, SET_ALARM, tgt as usize, 0);
         if clock.get_time() >= clock.client_setpoint.get() {
             clock.client_setpoint.set(u64::max_value());
-            clock.forwarder.invoke_callback(AlarmFired);
+            clock.client_ptr.callback(AlarmFired);
             continue;
         }
         break;

--- a/zst_pointer_async/lw/time.rs
+++ b/zst_pointer_async/lw/time.rs
@@ -1,0 +1,123 @@
+//! Lightweight Timer/Alarm interface.
+
+// Most of Clock's complexity comes from un-wrapping the 32-bit counter exposed
+// by the kernel into a 64-bit counter. To do this, we make sure to set alarms
+// no longer than UPDATE_PERIOD apart, so that we can catch wrapping events.
+//
+// Note that we cannot set UPDATE_PERIOD to 2^32 or 2^32 - 1, as otherwise the
+// following two sequences of events would be indistinguishable:
+//   Alarm expires           get_time() is called
+//   get_time() is called    Alarm expires
+//   Alarm callback runs     Alarm callback runs
+// In the first sequence, the get_time() call needs to handle the full
+// wraparound, but the numbers returned by the kernel would match the second
+// sequence. Therefore, we need all queued alarm callbacks to run less than
+// 2^32 - UPDATE_PERIOD ticks after the alarm fires. We don't have a way to make
+// that happen (as Tock is not a RTOS) so we simply hope such a large delay
+// never happens.
+
+use crate::lw::async_util::Forwarder;
+use crate::syscalls::{command, subscribe_ptr};
+
+const DRIVER_NUM: usize = 0;
+const GET_TICKS: usize = 2;
+const SET_ALARM: usize = 4;
+const ALARM_FIRED: usize = 0;
+const UPDATE_PERIOD: u32 = 1_000_000_000;
+
+pub struct Clock<F: Forwarder<AlarmFired>> {
+    // The time at which the client wants to be alerted.
+    client_setpoint: core::cell::Cell<u64>,
+
+    // Time as of init or the last kernel alarm. The lower 32 bits equal the
+    // kernel counter value at that time.
+    last_callback: core::cell::Cell<u64>,
+
+    forwarder: F,
+}
+
+pub trait AlarmClock {
+    fn get_time(&self) -> u64;
+    fn get_alarm(&self) -> u64;
+    fn set_alarm(&self, time: u64) -> Result<(), InPast>;
+}
+
+impl<F: Forwarder<AlarmFired>> Clock<F> {
+    pub const fn new(forwarder: F) -> Clock<F> {
+        Clock {
+            client_setpoint: core::cell::Cell::new(0),
+            last_callback: core::cell::Cell::new(0),
+            forwarder
+        }
+    }
+
+    // TODO: Figure out if we want to enforce init() before using the clock +
+    // design the mechanism for doing so.
+    pub fn init(&self) {
+        unsafe {
+            subscribe_ptr(DRIVER_NUM, ALARM_FIRED, callback::<F> as *const _,
+                          self as *const Self as usize);
+        }
+        self.client_setpoint.set(u64::max_value());
+        self.last_callback.set(unsafe { command(DRIVER_NUM, GET_TICKS, 0, 0) } as u64);
+        let callback_ticks = (self.last_callback.get() as u32).wrapping_add(UPDATE_PERIOD);
+        unsafe { command(DRIVER_NUM, SET_ALARM, callback_ticks as usize, 0) };
+    }
+}
+
+impl<F: Forwarder<AlarmFired>> AlarmClock for Clock<F> {
+    fn get_time(&self) -> u64 {
+        calc_new_unwrapped(
+            self.last_callback.get(),
+            unsafe { command(DRIVER_NUM, GET_TICKS, 0, 0) } as u32,
+        )
+    }
+
+    // Returns u64::max_value() if no alarm is set.
+    fn get_alarm(&self) -> u64 {
+        self.client_setpoint.get()
+    }
+
+    fn set_alarm(&self, time: u64) -> Result<(), InPast> {
+        self.client_setpoint.set(time);
+        if time >= self.last_callback.get() + UPDATE_PERIOD as u64 {
+            return Ok(());
+        }
+        unsafe { command(DRIVER_NUM, SET_ALARM, time as usize, 0) };
+        if self.get_time() >= time {
+            let callback_ticks = (self.last_callback.get() as u32).wrapping_add(UPDATE_PERIOD);
+            unsafe { command(DRIVER_NUM, SET_ALARM, callback_ticks as usize, 0) };
+            self.client_setpoint.set(u64::max_value());
+            return Err(InPast);
+        }
+        Ok(())
+    }
+}
+
+pub struct AlarmFired;
+pub struct InPast;
+
+// Finds the next 64-bit time value that matches the provided 32-bit kernel time
+// value.
+fn calc_new_unwrapped(unwrapped: u64, ticks: u32) -> u64 {
+    unwrapped + ticks.wrapping_sub(unwrapped as u32) as u64
+}
+
+// We don't use crate::syscalls::subscribe as that requires a unique reference
+// and we need subscribe to work with a shared reference. This is the callback
+// we use instead.
+unsafe extern fn callback<F: Forwarder<AlarmFired>>(_: usize, expired: usize, _: usize, clock: usize) {
+    use core::cmp::min;
+    let clock = &*(clock as *const Clock<F>);
+    clock.last_callback.set(calc_new_unwrapped(clock.last_callback.get(), expired as u32));
+    loop {
+        let tgt = min(clock.client_setpoint.get(), clock.last_callback.get() + UPDATE_PERIOD as u64);
+        command(DRIVER_NUM, SET_ALARM, tgt as usize, 0);
+        if clock.get_time() >= clock.client_setpoint.get() {
+            clock.client_setpoint.set(u64::max_value());
+            clock.forwarder.invoke_callback(AlarmFired);
+            continue;
+        }
+        break;
+    }
+}

--- a/zst_pointer_async/lw/virt_time.rs
+++ b/zst_pointer_async/lw/virt_time.rs
@@ -1,4 +1,4 @@
-use crate::lw::async_util::{Client, DynClient, Forwarder, TockStatic};
+use crate::lw::async_util::{AsyncClientPtr, Client, DynClient, TockStatic};
 use crate::lw::sync_cell::SyncCell;
 use crate::lw::time::{AlarmClock, AlarmFired, Clock, InPast};
 
@@ -52,13 +52,13 @@ impl AlarmClock for MuxClient {
     }
 }
 
-pub static CLOCK: TockStatic<Clock<MuxForwarder>> = TockStatic::new(Clock::new(MuxForwarder));
+pub static CLOCK: TockStatic<Clock<MuxClientPtr>> = TockStatic::new(Clock::new(MuxClientPtr));
 
 #[derive(Clone, Copy)]
-pub struct MuxForwarder;
+pub struct MuxClientPtr;
 
-impl Forwarder<AlarmFired> for MuxForwarder {
-    fn invoke_callback(self, _response: AlarmFired) {
+impl AsyncClientPtr<AlarmFired> for MuxClientPtr {
+    fn callback(self, _output: AlarmFired) {
         loop {
             let time = CLOCK.get_time();
             let mut cur_muxclient = MUX.head.get();

--- a/zst_pointer_async/lw/virt_time.rs
+++ b/zst_pointer_async/lw/virt_time.rs
@@ -1,0 +1,88 @@
+use crate::lw::async_util::{Client, DynClient, Forwarder, TockStatic};
+use crate::lw::sync_cell::SyncCell;
+use crate::lw::time::{AlarmClock, AlarmFired, Clock, InPast};
+
+pub static MUX: Mux = Mux {
+    head: SyncCell::new(None),
+};
+
+pub struct Mux {
+    head: SyncCell<Option<&'static MuxClient>>,
+}
+
+pub struct MuxClient {
+    dyn_client: TockStatic<DynClient<'static, AlarmFired>>,
+    next: SyncCell<Option<&'static MuxClient>>,
+    setpoint: SyncCell<Option<u64>>,
+}
+
+impl MuxClient {
+    pub const fn new<C: Client<AlarmFired>>(client: &'static C) -> MuxClient {
+        MuxClient {
+            dyn_client: TockStatic::new(DynClient::new(client)),
+            next: SyncCell::new(None),
+            setpoint: SyncCell::new(None),
+        }
+    }
+}
+
+impl AlarmClock for MuxClient {
+    fn get_time(&self) -> u64 {
+        CLOCK.get_time()
+    }
+
+    fn get_alarm(&self) -> u64 {
+        self.setpoint.get().unwrap_or(u64::max_value())
+    }
+
+    fn set_alarm(&self, time: u64) -> Result<(), InPast> {
+        if CLOCK.get_alarm() > time {
+            // TODO: Implementing this correctly requires a deferred call
+            // mechanism. If CLOCK.set_alarm returns Err(InPast), we not only
+            // need to return InPast, we may also need to run callbacks and we
+            // need to reset the existing alarm in CLOCK.
+
+            // TODO: Perhaps it should've been a deferred-call-based mechanism
+            // from the start? Maybe the APIs shouldn't be the same?
+            return CLOCK.set_alarm(time);
+        }
+
+        self.setpoint.set(Some(time));
+        Ok(())
+    }
+}
+
+pub static CLOCK: TockStatic<Clock<MuxForwarder>> = TockStatic::new(Clock::new(MuxForwarder));
+
+#[derive(Clone, Copy)]
+pub struct MuxForwarder;
+
+impl Forwarder<AlarmFired> for MuxForwarder {
+    fn invoke_callback(self, _response: AlarmFired) {
+        loop {
+            let time = CLOCK.get_time();
+            let mut cur_muxclient = MUX.head.get();
+            while let Some(muxclient) = cur_muxclient {
+                if let Some(setpoint) = muxclient.setpoint.get() {
+                    if setpoint <= time {
+                        // Set the setpoint 0 in case it is overwritten by the
+                        // callback.
+                        muxclient.setpoint.set(None);
+                        muxclient.dyn_client.callback(AlarmFired);
+                    }
+                }
+                cur_muxclient = muxclient.next.get();
+            }
+            let mut next_alarm = u64::max_value();
+            cur_muxclient = MUX.head.get();
+            while let Some(muxclient) = cur_muxclient {
+                if let Some(setpoint) = muxclient.setpoint.get() {
+                    if setpoint < next_alarm { next_alarm = setpoint; }
+                }
+            }
+            if next_alarm == u64::max_value() || CLOCK.set_alarm(next_alarm).is_ok() {
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have mentioned that I am experimenting with some ideas for lightweight asynchronous library design. Until now, I haven't described those ideas, because I was not confident that they are workable and *they are surprisingly difficult to describe*.

Here they are!

At this point, I am confident that we can construct a usable, lightweight syscall driver interface using my "ZST pointer" idea. Note that I haven't nailed down many of the details (such as which approach(s) we should take for handling `Sync`, or whether to use the generic traits I proposed), and those should be discussed in `libtock-rs` issues and PRs.

[Rendered](https://www.github.com/tock/design-explorations/tree/static-clients/zst_pointer_async)