### PR TITLE
`allow::Ref`-based Allow API design.

### DIFF
--- a/allow_pin/src/allow_ref.rs
+++ b/allow_pin/src/allow_ref.rs
@@ -1,0 +1,76 @@
+//! A design based around the `allow::Ref` type, which is a type that can point
+//! to both 'static and stack-based buffers. `allow::Ref` itself is type (and
+//! lifetime)-erased to avoid monomorphization bloat in APIs. However, it is
+//! limited to only RO Allows or only RW Allows (because only allow::Ref<Ro> can
+//! be created from a `&'static [u8]`).
+
+pub type ErrorCode = u32;
+
+pub mod allow {
+    use core::ptr::null_mut;
+    use crate::*;
+
+    /// A reference to something that can be shared with the kernel via the
+    /// Read-Only Allow system call (and if P is Rw, read-write Allow).
+    pub struct Ref<P: Permissions, T: Allowable> {
+        // The lifetime is erased to 'static here. There is no correct lifetime to
+        // write when an AllowRef is embedded inside a Buffer.
+        buffer: P::BufRef<'static, T>,
+        // APIs need to be able to retrieve mutable references to the buffer
+        // (for RW Allow), which requires that they have an exclusive reference
+        // to the Ref. However, giving an &mut reference to the Ref would allow
+        // the buffer to replace the Ref and forget it, which would prevent the
+        // unallow from occurring before the buffer is dropped. To prevent that,
+        // we pin the Ref as well.
+        _pinned: PhantomPinned,
+        share_info: Option<ShareInfo>,
+    }
+
+    impl<P: Permissions, T: Allowable> Ref<P, T> {
+        fn unshare_if_shared(self: Pin<&mut Self>) {
+            let this = unsafe { Pin::into_inner_unchecked(self) };
+            let Some(ref info) = this.share_info else { return };
+            unsafe {
+                dynamic_allow(info.driver_num, info.buffer_num, null_mut(), 0, info.allow_type);
+            }
+            this.share_info = None;
+        }
+    }
+
+    struct ShareInfo {
+        allow_type: DynamicType,
+        driver_num: u32,
+        buffer_num: u32,
+    }
+
+    /// Trait representing an allowable type.
+    pub trait Allowable: FromBytes + IntoBytes + 'static {}
+    impl<T: FromBytes + IntoBytes + ?Sized + 'static> Allowable for T {}
+
+    /// A type that represents whether a `Ref` has write access to a buffer.
+    pub trait Permissions: sealed::Sealed {
+        type BufRef<'b, T: Allowable>;
+        // Only exists within the context of this design exploration; would not
+        // exist in libtock-rs (because Permissions replaces StaticType
+        // entirely).
+        type Static: StaticType;
+    }
+
+    // Permissions implementations.
+    pub enum Ro {}
+    impl sealed::Sealed for Ro {}
+    impl Permissions for Ro {
+        type BufRef<'b, T: Allowable> = &'b T;
+        type Static = StaticRo;
+    }
+    pub enum Rw {}
+    impl sealed::Sealed for Rw {}
+    impl Permissions for Rw {
+        type BufRef<'b, T: Allowable> = &'b mut T;
+        type Static = StaticRw;
+    }
+
+    mod sealed {
+        pub trait Sealed {}
+    }
+}

--- a/allow_pin/src/allow_ref.rs
+++ b/allow_pin/src/allow_ref.rs
@@ -1,43 +1,81 @@
 //! A design based around the `allow::Ref` type, which is a type that can point
-//! to both 'static and stack-based buffers. `allow::Ref` itself is type (and
-//! lifetime)-erased to avoid monomorphization bloat in APIs. However, it is
-//! limited to only RO Allows or only RW Allows (because only allow::Ref<Ro> can
-//! be created from a `&'static [u8]`).
+//! to both 'static and stack-based buffers.
 
 pub type ErrorCode = u32;
 
 pub mod allow {
-    use core::ptr::null_mut;
     use crate::*;
+    use core::cell::Cell;
+    use core::ptr::null_mut;
 
-    /// A reference to something that can be shared with the kernel via the
-    /// Read-Only Allow system call (and if P is Rw, read-write Allow).
-    pub struct Ref<P: Permissions, T: Allowable> {
-        // The lifetime is erased to 'static here. There is no correct lifetime to
-        // write when an AllowRef is embedded inside a Buffer.
-        buffer: P::BufRef<'static, T>,
-        // APIs need to be able to retrieve mutable references to the buffer
-        // (for RW Allow), which requires that they have an exclusive reference
-        // to the Ref. However, giving an &mut reference to the Ref would allow
-        // the buffer to replace the Ref and forget it, which would prevent the
-        // unallow from occurring before the buffer is dropped. To prevent that,
-        // we pin the Ref as well.
-        _pinned: PhantomPinned,
-        share_info: Option<ShareInfo>,
+    pub struct Buffer<T: Allowable + ?Sized> {
+        share_info: Cell<Option<ShareInfo>>,
+        buffer: T,
     }
 
-    impl<P: Permissions, T: Allowable> Ref<P, T> {
-        fn unshare_if_shared(self: Pin<&mut Self>) {
-            let this = unsafe { Pin::into_inner_unchecked(self) };
-            let Some(ref info) = this.share_info else { return };
-            unsafe {
-                dynamic_allow(info.driver_num, info.buffer_num, null_mut(), 0, info.allow_type);
+    impl<T: Allowable> From<T> for Buffer<T> {
+        fn from(buffer: T) -> Buffer<T> {
+            Buffer {
+                share_info: Cell::new(None),
+                buffer,
             }
-            this.share_info = None;
         }
     }
 
-    struct ShareInfo {
+    impl<T: Allowable + ?Sized> Drop for Buffer<T> {
+        fn drop(&mut self) {
+            if let Some(info) = self.share_info.take() {
+                unsafe {
+                    dynamic_allow(
+                        info.driver_num,
+                        info.buffer_num,
+                        null_mut(),
+                        0,
+                        info.allow_type,
+                    );
+                }
+            }
+        }
+    }
+
+    impl<T: Allowable + ?Sized> Buffer<T> {
+        pub fn allow_ref<'s>(self: Pin<&'s Buffer<T>>) -> AllowRef<&'s T> {
+            let this = unsafe { Pin::into_inner_unchecked(self) };
+            AllowRef {
+                buffer: &this.buffer,
+                share_info: Some(&this.share_info),
+            }
+        }
+    }
+
+    /// A reference to a buffer that may be shared with the kernel. P should be either a `&T` or a
+    /// `&mut T`.
+    // TODO: Is there a way to remove the explicit 'b from here and instead get it through the Ptr
+    // trait? I don't want AllowRef<'b, &'b u8> showing up everywhere.
+    pub struct AllowRef<'b, P: Ptr<'b>> {
+        // Safety invariant: if share_info is Some(...), then the buffer referred to by share_info
+        // will be unallowed before `buffer`'s pointee is dropped. If `share_info` is `None`, then
+        // `buffer` is 'static and does not need to be unshared.
+        buffer: P,
+        share_info: Option<P::LifetimeRef<Cell<Option<ShareInfo>>>>,
+    }
+
+    impl<T: Allowable + ?Sized> AllowRef<&'static T> {
+        pub fn new_static(buffer: &'static T) -> AllowRef<&'static T> {
+            todo!()
+        }
+    }
+
+    impl<T: Allowable + ?Sized> AllowRef<&'static mut T> {
+        pub fn new_static(buffer: &'static mut T) -> AllowRef<&'static mut T> {
+            todo!()
+        }
+    }
+
+    impl<'b, T: Allowable + ?Sized> AllowRef<&'b T> {}
+
+    #[derive(Clone, Copy)]
+    pub struct ShareInfo {
         allow_type: DynamicType,
         driver_num: u32,
         buffer_num: u32,
@@ -47,30 +85,23 @@ pub mod allow {
     pub trait Allowable: FromBytes + IntoBytes + 'static {}
     impl<T: FromBytes + IntoBytes + ?Sized + 'static> Allowable for T {}
 
-    /// A type that represents whether a `Ref` has write access to a buffer.
-    pub trait Permissions: sealed::Sealed {
-        type BufRef<'b, T: Allowable>;
-        // Only exists within the context of this design exploration; would not
-        // exist in libtock-rs (because Permissions replaces StaticType
-        // entirely).
-        type Static: StaticType;
+    /// Reference type that an AllowRef can be.
+    pub trait Ptr<'b>: sealed::Sealed {
+        // For internal use
+        type LifetimeRef<T: 'b>;
     }
 
-    // Permissions implementations.
-    pub enum Ro {}
-    impl sealed::Sealed for Ro {}
-    impl Permissions for Ro {
-        type BufRef<'b, T: Allowable> = &'b T;
-        type Static = StaticRo;
+    impl<'a, B: Allowable + ?Sized> Ptr for &'a B {
+        type LifetimeRef<T: 'a> = &'a T;
     }
-    pub enum Rw {}
-    impl sealed::Sealed for Rw {}
-    impl Permissions for Rw {
-        type BufRef<'b, T: Allowable> = &'b mut T;
-        type Static = StaticRw;
+    impl<'a, B: Allowable + ?Sized> Ptr for &'a mut B {
+        type LifetimeRef<T: 'a> = &'a T;
     }
 
     mod sealed {
         pub trait Sealed {}
+
+        impl<'a, T: super::Allowable + ?Sized> Sealed for &'a T {}
+        impl<'a, T: super::Allowable + ?Sized> Sealed for &'a mut T {}
     }
 }

--- a/allow_pin/src/lib.rs
+++ b/allow_pin/src/lib.rs
@@ -6,6 +6,7 @@ use core::pin::Pin;
 use core::ptr::null_mut;
 use zerocopy::{FromBytes, IntoBytes};
 
+pub mod allow_ref;
 pub mod dynamic_type;
 pub mod full_dynamic;
 pub mod no_dynamic;


### PR DESCRIPTION
Note: This is currently far from complete, just publishing so no-one else duplicates the effort I've already put into it.

This is attempt to resolve the last question from this comment: https://github.com/jrvanwhy/design-explorations/pull/1#issuecomment-3304666018

The problem is that we want developers to be able to write APIs that can take both stack-allocated buffers and buffers from `.rodata` (and ideally `.data` as well) without having to duplicate all their code. The idea is that APIs would take a `Pin<&mut allow::Ref<>>`:

```rust
fn console_write(to_write: Pin<&mut allow::Ref<Rw, [u8]>>) -> Result<usize, ErrorCode>;
```

`allow::Ref` can be constructed from a `&'static [u8]`, `&'static mut [u8]`, `allow::Buffer`, etc. so APIs that accept an `allow::Ref` can be used in several different contexts.

Under this design, it will still be possible to use an `allow::Buffer` directly to perform Allow calls, as some API implementations (particularly those that only need small, fixed-size buffers) may choose to allocate their own buffers internally.