### PR TITLE
tock-registers redesign prototype (this is at least design 3)

### DIFF
--- a/registers_redesign_3/Cargo.toml
+++ b/registers_redesign_3/Cargo.toml
@@ -1,0 +1,7 @@
+# tock-registers designs sometimes bump into visibility and orphan rule issues,
+# so instead of prototyping inside a playground crate we prototype inside a
+# playground workspace.
+
+[workspace]
+members = ["driver", "mmio", "registers"]
+resolver = "3"

--- a/registers_redesign_3/README.md
+++ b/registers_redesign_3/README.md
@@ -1,0 +1,419 @@
+# Tock-registers redesign idea
+
+This is a design concept for tock-registers that:
+
+1. Fixes the reference-to-register soundness issue
+1. Makes drivers unit-testable
+1. Retains the ability for crates external to tock-registers to define new
+   register types (e.g. RISC-V CSRs).
+1. Supports LiteX registers (via the same mechanism as new register types).
+1. Allows for conditionally-compiled registers.
+1. Allows larger register blocks to be built out of smaller register blocks.
+
+## Declaration syntax
+
+First, an example of the declaration syntax, showing what this design should be
+able to do:
+
+```rust
+use tock_registers::registers;
+
+registers! {
+    // An individual register, which can be re-used later.
+    // Roughly equivalent to (from tock registers v1):
+    //     type Status = ReadOnly<u8>;
+    status: u8 { Read },
+
+    // A register array, which can be re-used later.
+    // Roughly equivalent to (from tock registers v1):
+    //     type Buttons = [ReadOnly<u8>; 4];
+    buttons: [u8; 4] { Read },
+
+    // Arrays can be created by referring to other registers too.
+    // Roughly equivalent to (from tock registers v1):
+    //     type StatusArray = [Status; 4];
+    status_array: [status; 4],
+
+    // A register block. This is the equivalent to register_structs!
+    simple_foo {
+        // This defines a field called simple_status, whose type is defined
+        // above as `status` (i.e. this is a read-only u8).
+        0x0 => simple_status: status,
+
+        // This defines a field called simple_buttons, whose type is the
+        // register array `buttons`.
+        0x1 => simple_buttons: buttons,
+
+        // This defines a register field inline. Most registers will be defined
+        // this way.
+        0x5 => control: u16 { Read, Write },
+    },
+
+    // A larger register block. This register block contains an instance of a
+    // simple_foo inside of itself.
+    complex_foo {
+        // The nested simple_foo
+        0x0 => nested_foo: simple_foo,
+
+        // An array of status registers.
+        0x7 => status_array: [status; 2],
+    },
+
+    // Arrays can be created out of register blocks as well.
+    many_simple_foos: [simple_foo; 8],
+
+    // All of the above are MMIO-only (and do not support LiteX). Types that
+    // want to support other uses need to explicitly declare what use cases they
+    // support:
+    #[bus_adapters(litex_registers::C8B32, litex_registers::C32B32)]
+    litex_foo {
+        0x0 => control: u16 { Read, Write },
+        // Different offsets for different bus adapters.
+        [0x8, 0x4] => status: u8 { Read },
+    },
+
+    #[bus_adapters(riscv_csrs::CSR)]
+    csr_foo {
+        // Different operation names are used here, because CSRs support
+        // different operations than MMIO registers. For example, they have
+        // read_and_set_bits and read_and_clear_bits operations. These operation
+        // names are traits, so the CSR traits are separate from the MMIO
+        // traits.
+        0x0 => example_csr: u32 { CsrRead, CsrWrite },
+    },
+
+    // Oh, and to keep the example's size limited, I don't show this, but:
+    // types should be able to refer to types defined in other crates/modules.
+    // I.e. simple_foo could be defined in one crate, which the crate that
+    // defines complex_foo depends on.
+}
+```
+
+## Module interface
+
+As shown above, register arrays and blocks should be able to nest arbitrarily.
+To support that, they all need to have the same interface (I use "interface"
+because it doesn't have an existing meaning in Rust). However, that interface
+needs to contain both traits and types, so the interface is a standardized
+module layout. That is why the register and peripheral blocks are in snake_case:
+they turn into module names rather than struct names in the generated code.
+
+The standardized module layout is:
+
+```rust
+// The module name matches the register/array/block name from the definition.
+mod foo {
+    // Names from the surrounding module are brought in by wildcard, so that
+    // callers can refer to types and modules by relative path.
+    use super::*;
+
+    // Trait with the public interface for the register/array/block. This
+    // interface can be implemented by fakes to support unit tests.
+    pub trait Interface: /* ... */ { /* ... */ }
+
+    // A trait defining which buses this register/array/blocks supports (MMIO is
+    // a bus, each LiteX layout is a bus, CSRs is a bus, etc). This trait is
+    // sealed; it is ONLY defined for the type(s) from `#[bus_adapters]`.
+    pub trait Bus: /* ... */ { /* ... */ }
+
+    // The type that implements Interface by calling out to real hardware (via
+    // MMIO or otherwise).
+    #[derive(Clone, Copy)]
+    pub struct GenericReal<B> {
+        bus: B,
+        pointer: NonNull<()>,
+    }
+
+    // There are a lot of other trait impls involved, but this is the key one
+    // for callers:
+    impl<B: Bus> Interface for GenericReal<B> where /* ... */ { /* ... */ }
+
+    // Convenience alias. If no `#[bus_adapters]` was specified, this will not
+    // have a generic argument. If `#[bus_adapters]` was specified, this is just
+    // an alias for GenericReal
+    pub type Real = GenericReal<tock_registers::Mmio>;
+}
+```
+
+## Basic register definition
+
+The simplest example we have is a single register defined on its own.
+
+```rust
+tock_registers::registers! {
+    // An individual register, which can be re-used later.
+    // Roughly equivalent to (from tock registers v1):
+    //     type Status = ReadOnly<u8>;
+    pub status: u8 { Read },
+}
+```
+
+expands to:
+
+```rust
+pub mod status {
+    use super::*;
+
+    pub trait Interface: Register<DataType = u8> + Read {}
+
+    pub trait Bus: Copy + sealed::Bus + registers::Bus<u8> {}
+    impl Bus for Mmio {}
+    mod sealed {
+        use crate::*;
+        pub trait Bus {}
+        impl Bus for Mmio {}
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct GenericReal<B> {
+        bus: B,
+        pointer: core::ptr::NonNull<()>,
+    }
+
+    impl<B: Bus> Interface for GenericReal<B> where Self: Register<DataType=u8> + Read {}
+
+    // RealBlock is a trait used to embed this register inside a larger register
+    // array or register blocks. It's an internal trait of tock_registers; users
+    // shouldn't have to interact with it directly.
+    impl<B: Bus> RealBlock for GenericReal<B> {
+        type Bus = B;
+        const ADDRESS_SIZE: usize = <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
+            Self { bus, pointer }
+        }
+    }
+
+    impl<B: Bus> Register for GenericReal<B> {
+        type DataType = u8;
+    }
+
+    // Each operation trait has a macro with the same name and path. The
+    // generated code calls into that macro to have the operation implemented.
+    Read!(real_impl, u8,);
+
+    pub type Real = GenericReal<Mmio>;
+}
+```
+
+## Array definition
+
+Next, lets take the `static` register from the previous definition and embed it
+into an array (by reference).
+
+```rust
+tock_registers::registers! {
+    // Arrays can be created by referring to other registers too.
+    // Roughly equivalent to (from tock registers v1):
+    //     type StatusArray = [Status; 4];
+    pub status_array: [status; 4],
+}
+```
+
+expands to:
+
+```rust
+pub mod status_array {
+    use super::*;
+
+    // ArrayRegister is a trait defined in tock_registers.
+    pub trait Interface: ArrayRegister<Element: status::Interface> {}
+
+    pub trait Bus: Copy + sealed::Bus + status::Bus {}
+    impl Bus for Mmio {}
+    mod sealed {
+        use crate::*;
+        pub trait Bus {}
+        impl Bus for Mmio {}
+    }
+
+    // Array registers do not require emitting a new struct, as they can be implemented as a
+    // generic type in tock_registers.
+    pub type GenericReal<B> = RealArrayRegister<status::GenericReal<B>, 4>;
+
+    impl<B: Bus> Interface for GenericReal<B> where Self: ArrayRegister<Element: status::Interface> {}
+
+    pub type Real = GenericReal<Mmio>;
+}
+```
+
+## Register block
+
+Stepping up the complexity a bit, lets create a register block that combines
+both of the above registers and adds a new register with an inline definition
+(note that inline definitions will be the most common case in practice).
+
+```rust
+tock_registers::registers! {
+    pub foo {
+        // status and status array refer to the previous two register types.
+        0x0 => status: status,
+        0x1 => status_array: status_array,
+
+        // An inline register definition.
+        0x5 => control: u8 { Read + Write },
+    }
+}
+```
+
+expands to:
+
+```Rust
+pub mod foo {
+    #![allow(non_camel_case_types)]
+    use super::*;
+
+    pub trait Interface: Copy {
+        type status: status::Interface;
+        fn status(self) -> Self::status;
+
+        type status_array: status_array::Interface;
+        fn status_array(self) -> Self::status_array;
+
+        type control: Register<DataType = u8> + Read + Write;
+        fn control(self) -> Self::control;
+    }
+
+    #[allow(non_upper_case_globals)]
+    pub trait Bus: Copy + sealed::Bus + status::Bus + status_array::Bus {
+        // These values are the offsets of each field.
+        const status: usize;
+        const status_array: usize;
+        const control: usize;
+    }
+    impl Bus for Mmio {
+        const status: usize = 0x0;
+        const status_array: usize = const {
+            assert!(Self::status + status::GenericReal::<Self>::ADDRESS_SIZE == 0x1);
+            0x1
+        };
+        const control: usize = const {
+            assert!(Self::status_array + status_array::GenericReal::<Self>::ADDRESS_SIZE == 0x5);
+            0x5
+        };
+    }
+    mod sealed {
+        use crate::*;
+        pub trait Bus {}
+        impl Bus for Mmio {}
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct GenericReal<B> {
+        bus: B,
+        pointer: core::ptr::NonNull<()>,
+    }
+
+    // To avoid name conflicts, the real implementations of inline-defined registers have real_
+    // prepended to them.
+    #[derive(Clone, Copy)]
+    pub struct real_control<B> {
+        bus: B,
+        pointer: core::ptr::NonNull<()>,
+    }
+
+    impl<B: Bus> RealBlock for real_control<B> {
+        type Bus = B;
+        const ADDRESS_SIZE: usize = <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
+            Self { bus, pointer }
+        }
+    }
+
+    impl<B: Bus> Register for real_control<B> {
+        type DataType = u8;
+    }
+
+    Read!(real_impl, real_control, u8,);
+    Write!(real_impl, real_control, u8,);
+
+    impl<B: Bus> Interface for GenericReal<B>
+    where
+        status::GenericReal<B>: status::Interface,
+        status_array::GenericReal<B>: status_array::Interface,
+        real_control<B>: Register<DataType = u8> + Read + Write,
+    {
+        type status = status::GenericReal<B>;
+        fn status(self) -> Self::status {
+            unsafe { Self::status::with_bus(self.pointer.byte_add(B::status), self.bus) }
+        }
+        type status_array = status_array::GenericReal<B>;
+        fn status_array(self) -> Self::status_array {
+            unsafe {
+                Self::status_array::with_bus(self.pointer.byte_add(B::status_array), self.bus)
+            }
+        }
+        type control = real_control<B>;
+        fn control(self) -> Self::control {
+            unsafe { Self::control::with_bus(self.pointer.byte_add(B::control), self.bus) }
+        }
+    }
+
+    impl<B: Bus> RealBlock for GenericReal<B> {
+        type Bus = B;
+        const ADDRESS_SIZE: usize = B::control + <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
+            Self { bus, pointer }
+        }
+    }
+
+    pub type Real = GenericReal<Mmio>;
+}
+```
+
+## Inline nested array
+
+Inline registers can have nested arrays:
+
+```rust
+tock_registers::registers! {
+    pub nested_array {
+        0x0 => array: [[u8; 2]; 3] { Read },
+    }
+}
+```
+
+expands to:
+
+```rust
+pub mod nested_array {
+    use super::*;
+
+    pub trait Interface:
+        ArrayRegister<Element: ArrayRegister<Element: Register<DataType = u8> + Read>>
+    {
+    }
+
+    pub trait Bus: Copy + sealed::Bus + registers::Bus<u8> {}
+    impl Bus for Mmio {}
+    mod sealed {
+        use crate::*;
+        pub trait Bus {}
+        impl Bus for Mmio {}
+    }
+
+    // For an inline-defined array, we need to generate a separate type for the inner value.
+    #[derive(Clone, Copy)]
+    pub struct Element<B: Bus> {
+        bus: B,
+        pointer: core::ptr::NonNull<()>,
+    }
+
+    impl<B: Bus> RealBlock for Element<B> {
+        type Bus = B;
+        const ADDRESS_SIZE: usize = <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
+            Self { bus, pointer }
+        }
+    }
+
+    impl<B: Bus> Register for Element<B> {
+        type DataType = u8;
+    }
+
+    Read!(real_impl, Bus, Element, u8,);
+
+    pub type GenericReal<B> = RealArrayRegister<RealArrayRegister<Element<B>, 2>, 3>;
+
+    pub type Real = GenericReal<Mmio>;
+}
+```

--- a/registers_redesign_3/driver/Cargo.toml
+++ b/registers_redesign_3/driver/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "driver"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mmio.path = "../mmio"
+registers.path = "../registers"

--- a/registers_redesign_3/driver/src/lib.rs
+++ b/registers_redesign_3/driver/src/lib.rs
@@ -1,0 +1,416 @@
+use mmio::*;
+use registers::*;
+
+// Remaining things:
+//   Figure out DataType (how does this interact with UIntLike, RegisterLongName, etc?)
+
+// tock_registers::registers! {
+//     // An individual register, which can be re-used later.
+//     // Roughly equivalent to (from tock registers v1):
+//     //     type Status = ReadOnly<u8>;
+//     pub status: u8 { Read },
+// }
+
+pub mod status {
+    use super::*;
+
+    pub trait Interface: Register<DataType = u8> + Read {}
+
+    pub trait Bus: Copy + sealed::Bus + registers::Bus<u8> {}
+    impl Bus for Mmio {}
+    mod sealed {
+        use crate::*;
+        pub trait Bus {}
+        impl Bus for Mmio {}
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct GenericReal<B> {
+        bus: B,
+        pointer: core::ptr::NonNull<()>,
+    }
+
+    impl<B: Bus> Interface for GenericReal<B> where Self: Register<DataType = u8> + Read {}
+
+    // Register blocks use RealBlock to construct register types. Most users of tock_registers
+    // won't use RealBlock directly; they will use the inherent methods instead.
+    impl<B: Bus> RealBlock for GenericReal<B> {
+        type Bus = B;
+        const ADDRESS_SIZE: usize = <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
+            Self { bus, pointer }
+        }
+    }
+
+    /// Public constructors for this GenericReal. Note that this is omitted in the other examples
+    /// and README.md (mostly to reduce code size, partially because I wrote this last and don't
+    /// want to update everything).
+    impl<B: Bus> GenericReal<B> {
+        /// Constructs a new register with a default Bus (e.g. an MMIO bus).
+        /// # Safety
+        /// `pointer` must point to a register of this type on bus `B`.
+        pub unsafe fn new(pointer: core::ptr::NonNull<()>) -> Self
+        where
+            B: Default,
+        {
+            // Safety: Same invariants
+            unsafe { <Self as RealBlock>::new(pointer) }
+        }
+        /// Constructs a new register with a default Bus (e.g. an MMIO bus).
+        /// # Safety
+        /// `pointer` must point to a register of this type on bus `B`.
+        pub unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
+            Self { bus, pointer }
+        }
+    }
+
+    impl<B: Bus> Register for GenericReal<B> {
+        type DataType = u8;
+    }
+
+    Read!(real_impl, GenericReal, u8,);
+
+    pub type Real = GenericReal<Mmio>;
+}
+
+// tock_registers::registers! {
+//     // Arrays can be created by referring to other registers too.
+//     // Roughly equivalent to (from tock registers v1):
+//     //     type StatusArray = [Status; 4];
+//     pub status_array: [status; 4],
+// }
+
+pub mod status_array {
+    use super::*;
+
+    // ArrayRegister is a trait defined in tock_registers.
+    pub trait Interface: ArrayRegister<Element: status::Interface> {}
+
+    pub trait Bus: Copy + sealed::Bus + status::Bus {}
+    impl Bus for Mmio {}
+    mod sealed {
+        use crate::*;
+        pub trait Bus {}
+        impl Bus for Mmio {}
+    }
+
+    // Array registers do not require emitting a new struct, as they can be implemented as a
+    // generic type in tock_registers.
+    pub type GenericReal<B> = RealArrayRegister<status::GenericReal<B>, 4>;
+
+    impl<B: Bus> Interface for GenericReal<B> where Self: ArrayRegister<Element: status::Interface> {}
+
+    pub type Real = GenericReal<Mmio>;
+}
+
+// tock_registers::registers! {
+//     pub foo {
+//         // status and status array refer to the previous two register types.
+//         0x0 => status: status,
+//         0x1 => status_array: status_array,
+//
+//         // An inline register definition.
+//         0x5 => control: u8 { Read + Write },
+//     }
+// }
+
+pub mod foo {
+    #![allow(non_camel_case_types)]
+    use super::*;
+
+    pub trait Interface: Copy {
+        type status: status::Interface;
+        fn status(self) -> Self::status;
+
+        type status_array: status_array::Interface;
+        fn status_array(self) -> Self::status_array;
+
+        type control: Register<DataType = u8> + Read + Write;
+        fn control(self) -> Self::control;
+    }
+
+    #[allow(non_upper_case_globals)]
+    pub trait Bus: Copy + sealed::Bus + status::Bus + status_array::Bus {
+        // These values are the offsets of each field.
+        const status: usize;
+        const status_array: usize;
+        const control: usize;
+    }
+    impl Bus for Mmio {
+        const status: usize = 0x0;
+        const status_array: usize = const {
+            assert!(Self::status + status::GenericReal::<Self>::ADDRESS_SIZE == 0x1);
+            0x1
+        };
+        const control: usize = const {
+            assert!(Self::status_array + status_array::GenericReal::<Self>::ADDRESS_SIZE == 0x5);
+            0x5
+        };
+    }
+    mod sealed {
+        use crate::*;
+        pub trait Bus {}
+        impl Bus for Mmio {}
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct GenericReal<B> {
+        bus: B,
+        pointer: core::ptr::NonNull<()>,
+    }
+
+    // To avoid name conflicts, the real implementations of inline-defined registers have real_
+    // prepended to them.
+    #[derive(Clone, Copy)]
+    pub struct real_control<B> {
+        bus: B,
+        pointer: core::ptr::NonNull<()>,
+    }
+
+    impl<B: Bus> RealBlock for real_control<B> {
+        type Bus = B;
+        const ADDRESS_SIZE: usize = <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
+            Self { bus, pointer }
+        }
+    }
+
+    impl<B: Bus> Register for real_control<B> {
+        type DataType = u8;
+    }
+
+    Read!(real_impl, real_control, u8,);
+    Write!(real_impl, real_control, u8,);
+
+    impl<B: Bus> Interface for GenericReal<B>
+    where
+        status::GenericReal<B>: status::Interface,
+        status_array::GenericReal<B>: status_array::Interface,
+        real_control<B>: Register<DataType = u8> + Read + Write,
+    {
+        type status = status::GenericReal<B>;
+        fn status(self) -> Self::status {
+            unsafe { Self::status::with_bus(self.pointer.byte_add(B::status), self.bus) }
+        }
+        type status_array = status_array::GenericReal<B>;
+        fn status_array(self) -> Self::status_array {
+            unsafe {
+                Self::status_array::with_bus(self.pointer.byte_add(B::status_array), self.bus)
+            }
+        }
+        type control = real_control<B>;
+        fn control(self) -> Self::control {
+            unsafe { Self::control::with_bus(self.pointer.byte_add(B::control), self.bus) }
+        }
+    }
+
+    impl<B: Bus> RealBlock for GenericReal<B> {
+        type Bus = B;
+        const ADDRESS_SIZE: usize = B::control + <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
+            Self { bus, pointer }
+        }
+    }
+
+    pub type Real = GenericReal<Mmio>;
+}
+
+// tock_registers::registers! {
+//     pub nested_array {
+//         0x0 => array: [[u8; 2]; 3] { Read },
+//     }
+// }
+
+pub mod nested_array {
+    use super::*;
+
+    pub trait Interface:
+        ArrayRegister<Element: ArrayRegister<Element: Register<DataType = u8> + Read>>
+    {
+    }
+
+    pub trait Bus: Copy + sealed::Bus + registers::Bus<u8> {}
+    impl Bus for Mmio {}
+    mod sealed {
+        use crate::*;
+        pub trait Bus {}
+        impl Bus for Mmio {}
+    }
+
+    // For an inline-defined array, we need to generate a separate type for the inner value.
+    #[derive(Clone, Copy)]
+    pub struct Element<B> {
+        bus: B,
+        pointer: core::ptr::NonNull<()>,
+    }
+
+    impl<B: Bus> RealBlock for Element<B> {
+        type Bus = B;
+        const ADDRESS_SIZE: usize = <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
+            Self { bus, pointer }
+        }
+    }
+
+    impl<B: Bus> Register for Element<B> {
+        type DataType = u8;
+    }
+
+    Read!(real_impl, Element, u8,);
+
+    pub type GenericReal<B> = RealArrayRegister<RealArrayRegister<Element<B>, 2>, 3>;
+
+    pub type Real = GenericReal<Mmio>;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    use core::{cell::Cell, ptr::NonNull};
+
+    #[test]
+    fn fake_foo() {
+        use crate::foo::Interface;
+        // Implements a fake Foo peripheral. This peripheral has he following behavior:
+        // 1. The control register acts like normal memory (it holds whatever value is written into
+        //    it).
+        // 2. It contains a u8 counter. Reading from `status` returns this counter.
+        // 3. Reading from `status_array` increments the counter by `control * (index + 1)`,
+        //    wrapping.
+        #[derive(Default)]
+        struct Fake {
+            status: Cell<u8>,
+            control: Cell<u8>,
+        }
+        impl<'f> Interface for &'f Fake {
+            type status = FakeStatus<'f>;
+            fn status(self) -> FakeStatus<'f> {
+                FakeStatus {
+                    fake: self,
+                    multiplier: 0,
+                }
+            }
+            type status_array = FakeStatusArray<'f>;
+            fn status_array(self) -> FakeStatusArray<'f> {
+                FakeStatusArray(self)
+            }
+            type control = FakeControl<'f>;
+            fn control(self) -> FakeControl<'f> {
+                FakeControl(self)
+            }
+        }
+        #[derive(Clone, Copy)]
+        struct FakeStatus<'f> {
+            fake: &'f Fake,
+            multiplier: u8,
+        }
+        impl status::Interface for FakeStatus<'_> {}
+        impl Read for FakeStatus<'_> {
+            fn read(self) -> u8 {
+                let value = self
+                    .fake
+                    .status
+                    .get()
+                    .wrapping_add(self.fake.control.get() * self.multiplier);
+                self.fake.status.set(value);
+                value
+            }
+        }
+        impl Register for FakeStatus<'_> {
+            type DataType = u8;
+        }
+        #[derive(Clone, Copy)]
+        struct FakeStatusArray<'f>(&'f Fake);
+        impl<'f> ArrayRegister for FakeStatusArray<'f> {
+            type Element = FakeStatus<'f>;
+            const LEN: usize = 4;
+            fn get(self, index: usize) -> Option<FakeStatus<'f>> {
+                if index >= 4 {
+                    return None;
+                }
+                Some(FakeStatus {
+                    fake: self.0,
+                    multiplier: (index + 1).try_into().unwrap(),
+                })
+            }
+        }
+        impl status_array::Interface for FakeStatusArray<'_> {}
+        #[derive(Clone, Copy)]
+        struct FakeControl<'f>(&'f Fake);
+        impl Read for FakeControl<'_> {
+            fn read(self) -> u8 {
+                self.0.control.get()
+            }
+        }
+        impl Write for FakeControl<'_> {
+            fn write(self, value: u8) {
+                self.0.control.set(value);
+            }
+        }
+        impl Register for FakeControl<'_> {
+            type DataType = u8;
+        }
+        let foo = Fake::default();
+        assert_eq!(foo.control().read(), 0);
+        assert_eq!(foo.status().read(), 0);
+        assert_eq!(foo.status_array().get(0).unwrap().read(), 0);
+        assert_eq!(foo.status_array().get(1).unwrap().read(), 0);
+        assert_eq!(foo.status_array().get(2).unwrap().read(), 0);
+        assert_eq!(foo.status_array().get(3).unwrap().read(), 0);
+        assert!(foo.status_array().get(4).is_none());
+        foo.control().write(1);
+        assert_eq!(foo.control().read(), 1);
+        assert_eq!(foo.status().read(), 0);
+        assert_eq!(foo.status_array().get(0).unwrap().read(), 1);
+        assert_eq!(foo.status_array().get(1).unwrap().read(), 3);
+        assert_eq!(foo.status_array().get(2).unwrap().read(), 6);
+        assert_eq!(foo.status_array().get(3).unwrap().read(), 10);
+        assert!(foo.status_array().get(4).is_none());
+        foo.control().write(2);
+        assert_eq!(foo.control().read(), 2);
+        assert_eq!(foo.status().read(), 10);
+        assert_eq!(foo.status_array().get(0).unwrap().read(), 12);
+        assert_eq!(foo.status_array().get(1).unwrap().read(), 16);
+        assert_eq!(foo.status_array().get(2).unwrap().read(), 22);
+        assert_eq!(foo.status_array().get(3).unwrap().read(), 30);
+        assert!(foo.status_array().get(4).is_none());
+    }
+
+    #[test]
+    fn foo_interface_impl() {
+        fn needs_interface<T: foo::Interface>(_: T) {}
+        needs_interface(unsafe { foo::Real::new(NonNull::dangling()) })
+    }
+
+    #[test]
+    fn nested_array_read() {
+        let mut array = [1u8, 2, 3, 4, 5, 6];
+        let real = unsafe {
+            <nested_array::Real as RealBlock>::new(NonNull::new_unchecked((&raw mut array).cast()))
+        };
+        assert_eq!(real.get(0).unwrap().get(0).unwrap().read(), 1);
+        assert_eq!(real.get(0).unwrap().get(1).unwrap().read(), 2);
+        assert!(real.get(0).unwrap().get(2).is_none());
+        assert_eq!(real.get(1).unwrap().get(0).unwrap().read(), 3);
+        assert_eq!(real.get(1).unwrap().get(1).unwrap().read(), 4);
+        assert!(real.get(1).unwrap().get(2).is_none());
+        assert_eq!(real.get(2).unwrap().get(0).unwrap().read(), 5);
+        assert_eq!(real.get(2).unwrap().get(1).unwrap().read(), 6);
+        assert!(real.get(2).unwrap().get(2).is_none());
+        assert!(real.get(3).is_none());
+    }
+
+    #[test]
+    fn status_array_read() {
+        let mut statuses = [1u8, 2, 3, 4];
+        let real = unsafe {
+            <status_array::Real as RealBlock>::new(NonNull::new_unchecked(
+                (&raw mut statuses).cast(),
+            ))
+        };
+        assert_eq!(real.get(0).unwrap().read(), 1);
+        assert_eq!(real.get(1).unwrap().read(), 2);
+        assert_eq!(real.get(2).unwrap().read(), 3);
+        assert_eq!(real.get(3).unwrap().read(), 4);
+    }
+}

--- a/registers_redesign_3/driver/src/lib.rs
+++ b/registers_redesign_3/driver/src/lib.rs
@@ -16,7 +16,7 @@ pub mod status {
 
     pub trait Interface: Register<DataType = u8> + Read {}
 
-    pub trait Bus: Copy + sealed::Bus + registers::Bus<u8> {}
+    pub trait Bus: Copy + sealed::Bus + registers::BusValue<u8> {}
     impl Bus for Mmio {}
     mod sealed {
         use crate::*;
@@ -36,7 +36,7 @@ pub mod status {
     // won't use RealBlock directly; they will use the inherent methods instead.
     impl<B: Bus> RealBlock for GenericReal<B> {
         type Bus = B;
-        const ADDRESS_SIZE: usize = <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        const ADDRESS_SIZE: usize = <B as registers::BusValue<u8>>::ADDRESS_SIZE;
         unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
             Self { bus, pointer }
         }
@@ -86,7 +86,10 @@ pub mod status_array {
     // ArrayRegister is a trait defined in tock_registers.
     pub trait Interface: ArrayRegister<Element: status::Interface> {}
 
-    pub trait Bus: Copy + sealed::Bus + status::Bus {}
+    pub trait Bus:
+        Copy + sealed::Bus + status::Bus + registers::Bus<Address: registers::AddableAddress>
+    {
+    }
     impl Bus for Mmio {}
     mod sealed {
         use crate::*;
@@ -130,7 +133,13 @@ pub mod foo {
     }
 
     #[allow(non_upper_case_globals)]
-    pub trait Bus: Copy + sealed::Bus + status::Bus + status_array::Bus {
+    pub trait Bus:
+        Copy
+        + sealed::Bus
+        + status::Bus
+        + status_array::Bus
+        + registers::Bus<Address: registers::AddableAddress>
+    {
         // These values are the offsets of each field.
         const status: usize;
         const status_array: usize;
@@ -169,7 +178,7 @@ pub mod foo {
 
     impl<B: Bus> RealBlock for real_control<B> {
         type Bus = B;
-        const ADDRESS_SIZE: usize = <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        const ADDRESS_SIZE: usize = <B as registers::BusValue<u8>>::ADDRESS_SIZE;
         unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
             Self { bus, pointer }
         }
@@ -206,7 +215,7 @@ pub mod foo {
 
     impl<B: Bus> RealBlock for GenericReal<B> {
         type Bus = B;
-        const ADDRESS_SIZE: usize = B::control + <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        const ADDRESS_SIZE: usize = B::control + <B as registers::BusValue<u8>>::ADDRESS_SIZE;
         unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
             Self { bus, pointer }
         }
@@ -229,7 +238,13 @@ pub mod nested_array {
     {
     }
 
-    pub trait Bus: Copy + sealed::Bus + registers::Bus<u8> {}
+    pub trait Bus:
+        Copy
+        + sealed::Bus
+        + registers::BusValue<u8>
+        + registers::Bus<Address: registers::AddableAddress>
+    {
+    }
     impl Bus for Mmio {}
     mod sealed {
         use crate::*;
@@ -246,7 +261,7 @@ pub mod nested_array {
 
     impl<B: Bus> RealBlock for Element<B> {
         type Bus = B;
-        const ADDRESS_SIZE: usize = <B as registers::Bus<u8>>::ADDRESS_SIZE;
+        const ADDRESS_SIZE: usize = <B as registers::BusValue<u8>>::ADDRESS_SIZE;
         unsafe fn with_bus(pointer: core::ptr::NonNull<()>, bus: B) -> Self {
             Self { bus, pointer }
         }

--- a/registers_redesign_3/mmio/Cargo.toml
+++ b/registers_redesign_3/mmio/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mmio"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+registers.path = "../registers"

--- a/registers_redesign_3/mmio/src/lib.rs
+++ b/registers_redesign_3/mmio/src/lib.rs
@@ -10,14 +10,17 @@ use registers::*;
 #[derive(Clone, Copy, Default)]
 pub struct Mmio;
 
-impl<T: UIntLike> Bus<T> for Mmio {
+impl Bus for Mmio {
+    type Address = core::ptr::NonNull<()>;
+}
+impl<T: UIntLike> BusValue<T> for Mmio {
     const ADDRESS_SIZE: usize = size_of::<T>();
 }
 
 /// A Bus that implements BusRead<T> can support Read implementations with DataType T. Other crates
 /// (e.g. LiteX registers) can implement this on their own buses so that Read works with them as
 /// well.
-pub trait BusRead<T: UIntLike>: Bus<T> {
+pub trait BusRead<T: UIntLike>: BusValue<T> {
     /// # Safety
     /// There must be a register of type T at `pointer`, and if the register itself has safety
     /// invariants (i.e. it is `UnsafeRead`) the caller must satisfy those.
@@ -33,7 +36,7 @@ impl<T: UIntLike> BusRead<T> for Mmio {
 /// A Bus that implements BusWrite<T> can support Write implementations with DataType T. Other
 /// crates (e.g. LiteX registers) can implement this on their own buses so that Write works with
 /// them as well.
-pub trait BusWrite<T: UIntLike>: Bus<T> {
+pub trait BusWrite<T: UIntLike>: BusValue<T> {
     /// # Safety
     /// There must be a register of type T at `pointer`, and if the register itself has safety
     /// invariants (i.e. it is `UnsafeWrite`) the caller must satisfy those.

--- a/registers_redesign_3/mmio/src/lib.rs
+++ b/registers_redesign_3/mmio/src/lib.rs
@@ -1,0 +1,95 @@
+// MMIO operations would be defined in the core tock-register crate, but other types (such as the
+// LiteX bus and RISC-V CSRs) should be defined in separate crates. To test that, this workspace
+// implements the MMIO operations in a separate crate.
+
+use core::mem::size_of;
+use core::ptr::{read_volatile, write_volatile};
+use registers::*;
+
+/// A bus that performs direct MMIO operations. This does not support LiteX.
+#[derive(Clone, Copy, Default)]
+pub struct Mmio;
+
+impl<T: UIntLike> Bus<T> for Mmio {
+    const ADDRESS_SIZE: usize = size_of::<T>();
+}
+
+/// A Bus that implements BusRead<T> can support Read implementations with DataType T. Other crates
+/// (e.g. LiteX registers) can implement this on their own buses so that Read works with them as
+/// well.
+pub trait BusRead<T: UIntLike>: Bus<T> {
+    /// # Safety
+    /// There must be a register of type T at `pointer`, and if the register itself has safety
+    /// invariants (i.e. it is `UnsafeRead`) the caller must satisfy those.
+    unsafe fn read(self, pointer: *const T) -> T;
+}
+
+impl<T: UIntLike> BusRead<T> for Mmio {
+    unsafe fn read(self, pointer: *const T) -> T {
+        unsafe { read_volatile(pointer) }
+    }
+}
+
+/// A Bus that implements BusWrite<T> can support Write implementations with DataType T. Other
+/// crates (e.g. LiteX registers) can implement this on their own buses so that Write works with
+/// them as well.
+pub trait BusWrite<T: UIntLike>: Bus<T> {
+    /// # Safety
+    /// There must be a register of type T at `pointer`, and if the register itself has safety
+    /// invariants (i.e. it is `UnsafeWrite`) the caller must satisfy those.
+    unsafe fn write(self, pointer: *mut T, value: T);
+}
+
+impl<T: UIntLike> BusWrite<T> for Mmio {
+    unsafe fn write(self, pointer: *mut T, value: T) {
+        unsafe { write_volatile(pointer, value) }
+    }
+}
+
+/// A register that can be read.
+pub trait Read: Register {
+    fn read(self) -> Self::DataType;
+}
+
+/// The macro that goes along with the Read trait. We don't expect this macro to be used by
+/// tock_register's users, instead it is invoked by the generated code.
+#[macro_export]
+macro_rules! Read {
+    // Provides a real implementation of the trait. The trailing $rest argument is for future
+    // compatibility: it allows the procedural macro to pass additional arguments in the future
+    // without breaking compatibility with this implementation of Read!.
+    (real_impl, $real_type:ident, $datatype:ty, $($rest:tt)*) => {
+        impl<B: Bus + $crate::BusRead<$datatype>> $crate::Read for $real_type<B> {
+            fn read(self) -> $datatype {
+                unsafe {
+                    self.bus
+                        .read(self.pointer.cast::<$datatype>().as_ptr().cast_const())
+                }
+            }
+        }
+    };
+}
+
+/// A register that can be written.
+pub trait Write: Register {
+    fn write(self, value: Self::DataType);
+}
+
+/// The macro that goes along with the Write trait. We don't expect this macro to be used by
+/// tock_register's users, instead it is invoked by the generated code.
+#[macro_export]
+macro_rules! Write {
+    // Provides a real implementation of the trait. The trailing $rest argument is for future
+    // compatibility: it allows the procedural macro to pass additional arguments in the future
+    // without breaking compatibility with this implementation of Read!.
+    (real_impl, $real_type:ident, $datatype:ty, $($rest:tt)*) => {
+        impl<B: Bus + $crate::BusWrite<$datatype>> $crate::Write for $real_type<B> {
+            fn write(self, value: $datatype) {
+                unsafe {
+                    self.bus
+                        .write(self.pointer.cast::<$datatype>().as_ptr(), value)
+                }
+            }
+        }
+    };
+}

--- a/registers_redesign_3/registers/Cargo.toml
+++ b/registers_redesign_3/registers/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "registers"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/registers_redesign_3/registers/src/lib.rs
+++ b/registers_redesign_3/registers/src/lib.rs
@@ -14,16 +14,32 @@ impl UIntLike for i128 {}
 
 /// A Bus provides some way to access register values. Examples include: direct MMIO, LiteX (which
 /// is memory-mapped but does not translate 1:1 to read_volatile/write_volatile), RISC-V CSRs, etc.
+pub trait Bus: Copy {
+    type Address: Copy;
+}
+
 /// MMIO provides access to any UIntLike type, but other bus types may only provide access to
 /// certain primitives. In that case, the bus will implement Bus<T> only for the corresponding T.
-pub trait Bus<T: UIntLike>: Copy {
+pub trait BusValue<T: UIntLike>: Bus {
     const ADDRESS_SIZE: usize;
+}
+
+/// A bus address type that can be offset.
+pub trait AddableAddress: Copy {
+    /// Safety: same as raw pointers' add function
+    unsafe fn add(self, offset: usize) -> Self;
+}
+
+impl AddableAddress for core::ptr::NonNull<()> {
+    unsafe fn add(self, offset: usize) -> core::ptr::NonNull<()> {
+        unsafe { self.add(offset) }
+    }
 }
 
 /// A block of registers. Every Real type implements this. This trait is used to construct the
 /// register blocks, including sub-blocks for larger register blocks.
 pub trait RealBlock: Copy {
-    type Bus: Copy;
+    type Bus: Bus;
     /// Size this blocks occupies in the address space. Depends on Bus.
     const ADDRESS_SIZE: usize;
 
@@ -58,13 +74,19 @@ pub trait ArrayRegister: Copy {
 
 /// Real implementation of ArrayRegister.
 #[derive(Clone, Copy)]
-pub struct RealArrayRegister<E: RealBlock, const LEN: usize> {
+pub struct RealArrayRegister<E: RealBlock, const LEN: usize>
+where
+    <E::Bus as Bus>::Address: AddableAddress,
+{
     bus: E::Bus,
     phantom: PhantomData<[E; LEN]>,
     pointer: NonNull<()>,
 }
 
-impl<E: RealBlock, const LEN: usize> ArrayRegister for RealArrayRegister<E, LEN> {
+impl<E: RealBlock, const LEN: usize> ArrayRegister for RealArrayRegister<E, LEN>
+where
+    <E::Bus as Bus>::Address: AddableAddress,
+{
     type Element = E;
     const LEN: usize = LEN;
 
@@ -78,7 +100,10 @@ impl<E: RealBlock, const LEN: usize> ArrayRegister for RealArrayRegister<E, LEN>
     }
 }
 
-impl<E: RealBlock, const LEN: usize> RealBlock for RealArrayRegister<E, LEN> {
+impl<E: RealBlock, const LEN: usize> RealBlock for RealArrayRegister<E, LEN>
+where
+    <E::Bus as Bus>::Address: AddableAddress,
+{
     type Bus = E::Bus;
     const ADDRESS_SIZE: usize = LEN * E::ADDRESS_SIZE;
 
@@ -93,7 +118,10 @@ impl<E: RealBlock, const LEN: usize> RealBlock for RealArrayRegister<E, LEN> {
 
 /// Inherent impl of the constuctors so callers don't have to use `<X as RealBlock>::new()` to
 /// construct arrays.
-impl<E: RealBlock, const LEN: usize> RealArrayRegister<E, LEN> {
+impl<E: RealBlock, const LEN: usize> RealArrayRegister<E, LEN>
+where
+    <E::Bus as Bus>::Address: AddableAddress,
+{
     /// Constructs a new register array with a default Bus (e.g. an MMIO bus).
     /// # Safety
     /// `pointer` must point to a register array of type E and length LEN on Bus `B`.

--- a/registers_redesign_3/registers/src/lib.rs
+++ b/registers_redesign_3/registers/src/lib.rs
@@ -1,0 +1,123 @@
+use core::{marker::PhantomData, ptr::NonNull};
+
+pub trait UIntLike {}
+impl UIntLike for u8 {}
+impl UIntLike for u16 {}
+impl UIntLike for u32 {}
+impl UIntLike for u64 {}
+impl UIntLike for u128 {}
+impl UIntLike for i8 {}
+impl UIntLike for i16 {}
+impl UIntLike for i32 {}
+impl UIntLike for i64 {}
+impl UIntLike for i128 {}
+
+/// A Bus provides some way to access register values. Examples include: direct MMIO, LiteX (which
+/// is memory-mapped but does not translate 1:1 to read_volatile/write_volatile), RISC-V CSRs, etc.
+/// MMIO provides access to any UIntLike type, but other bus types may only provide access to
+/// certain primitives. In that case, the bus will implement Bus<T> only for the corresponding T.
+pub trait Bus<T: UIntLike>: Copy {
+    const ADDRESS_SIZE: usize;
+}
+
+/// A block of registers. Every Real type implements this. This trait is used to construct the
+/// register blocks, including sub-blocks for larger register blocks.
+pub trait RealBlock: Copy {
+    type Bus: Copy;
+    /// Size this blocks occupies in the address space. Depends on Bus.
+    const ADDRESS_SIZE: usize;
+
+    /// Constructs a new register block.
+    /// # Safety
+    /// `pointer` must point to registers on Bus `bus` with the layout that correctly matches this
+    /// type's definition.
+    unsafe fn with_bus(pointer: NonNull<()>, bus: Self::Bus) -> Self;
+
+    /// Constructs a new register block with a default Bus (e.g. an MMIO bus).
+    /// # Safety
+    /// `pointer` must point to registers on Bus `B` with the layout that correctly matches this
+    /// type's definition.
+    unsafe fn new(pointer: NonNull<()>) -> Self
+    where
+        Self::Bus: Default,
+    {
+        unsafe { Self::with_bus(pointer, Default::default()) }
+    }
+}
+
+/// Interface for an array register.
+// Note: We probably also want traits for infallible indexing (for registers arrays of exactly 2^8
+// or 2^16 entries). Don't need to prototype here though, that's something to implement in the full
+// version (if it doesn't work then we can just ignore it).
+pub trait ArrayRegister: Copy {
+    /// The type of an element of this array.
+    type Element: Copy;
+    const LEN: usize;
+    fn get(self, index: usize) -> Option<Self::Element>;
+}
+
+/// Real implementation of ArrayRegister.
+#[derive(Clone, Copy)]
+pub struct RealArrayRegister<E: RealBlock, const LEN: usize> {
+    bus: E::Bus,
+    phantom: PhantomData<[E; LEN]>,
+    pointer: NonNull<()>,
+}
+
+impl<E: RealBlock, const LEN: usize> ArrayRegister for RealArrayRegister<E, LEN> {
+    type Element = E;
+    const LEN: usize = LEN;
+
+    fn get(self, index: usize) -> Option<E> {
+        if index >= LEN {
+            return None;
+        }
+        let base = self.pointer;
+        let offset = index * E::ADDRESS_SIZE;
+        Some(unsafe { E::with_bus(base.byte_add(offset), self.bus) })
+    }
+}
+
+impl<E: RealBlock, const LEN: usize> RealBlock for RealArrayRegister<E, LEN> {
+    type Bus = E::Bus;
+    const ADDRESS_SIZE: usize = LEN * E::ADDRESS_SIZE;
+
+    unsafe fn with_bus(pointer: NonNull<()>, bus: E::Bus) -> Self {
+        RealArrayRegister {
+            bus,
+            phantom: PhantomData,
+            pointer,
+        }
+    }
+}
+
+/// Inherent impl of the constuctors so callers don't have to use `<X as RealBlock>::new()` to
+/// construct arrays.
+impl<E: RealBlock, const LEN: usize> RealArrayRegister<E, LEN> {
+    /// Constructs a new register array with a default Bus (e.g. an MMIO bus).
+    /// # Safety
+    /// `pointer` must point to a register array of type E and length LEN on Bus `B`.
+    pub unsafe fn new(pointer: NonNull<()>) -> Self
+    where
+        E::Bus: Default,
+    {
+        // Safety: Same invariants as this function.
+        unsafe { <Self as RealBlock>::new(pointer) }
+    }
+
+    /// Constructs a new register array.
+    /// # Safety
+    /// `pointer` must point to a register array of type E and length LEN on Bus `bus`.
+    pub unsafe fn with_bus(pointer: NonNull<()>, bus: E::Bus) -> Self {
+        RealArrayRegister {
+            bus,
+            phantom: PhantomData,
+            pointer,
+        }
+    }
+}
+
+/// Type implemented by all registers.
+pub trait Register: Copy {
+    type DataType;
+}

--- a/registers_redesign_3/rust-toolchain.toml
+++ b/registers_redesign_3/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-11-03"
+components = ["miri", "rust-src"]


### PR DESCRIPTION
[Rendered](https://github.com/jrvanwhy/design-explorations/tree/registers-redesign-3/registers_redesign_3)

This expands upon https://github.com/tock/tock/pull/4001 to add the following features:

1. Individual registers can be defined and re-used (this replicates the `type Foo = ReadWrite<...>;` functionality of the existing register_structs! macro).
2. Array registers can be defined and re-used (replicates `type FooArray = [ReadWrite<...>; 8];`)
3. Register blocks can be defined and re-used (i.e. a block of registers can be nested in another block).
4. Re-works how arrays work, so that the Read/Write/etc traits don't need to have methods for both scalar and array accesses. Also allows for nested arrays.
5. Supports register types other than MMIO registers, such as CSRs (it is no longer hard-coded to only support Read + Write).

The unfortunate drawback is an increase in the amount of generated code. Fortunately, there is a bit more modularity: there is a core module "interface" that everything fits, which allows the generated code for register blocks to refer to registers/arrays/nested blocks without needing to know the definitions of those types. So in that respect it's more modular, it's just that because the interface is not a defined thing like a trait it is harder to communicate/understand.

I have not worked out how this interacts with RegisterLongName, but I'm confident it's possible to work that out and I want to get feedback on this sooner rather than later.